### PR TITLE
Resource id buttons

### DIFF
--- a/__tests__/components/ResourceCounts.test.tsx
+++ b/__tests__/components/ResourceCounts.test.tsx
@@ -28,10 +28,10 @@ describe("resource Counts render", () => {
       render(mantineRecoilWrap(<ResourceCounts />));
     });
 
-    expect(screen.getByRole("button", { name: "Patient 2" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Measure 5" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Account 0" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Appointment 0" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Patient 2" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Measure 5" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Account 0" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Appointment 0" })).toBeInTheDocument();
   });
 
   it("the retrieved resources should be sorted by count, then alphabetically", async () => {

--- a/__tests__/components/ResourceId.test.tsx
+++ b/__tests__/components/ResourceId.test.tsx
@@ -7,72 +7,68 @@ import {
 } from "../helpers/testHelpers";
 import ResourceIDs from "../../components/ResourceIDs";
 
-const RESOURCE_ID_BODY  = {
-        "resourceType": "Bundle",
-        "meta": {
-            "lastUpdated": "2022-06-23T19:52:58.721Z"
+const RESOURCE_ID_BODY = {
+  resourceType: "Bundle",
+  meta: {
+    lastUpdated: "2022-06-23T19:52:58.721Z",
+  },
+  type: "searchset",
+  total: 2,
+  entry: [
+    {
+      fullUrl: "http://localhost:3000/4_0_1/DiagnosticReport/denom-EXM125-3",
+      resource: {
+        resourceType: "DiagnosticReport",
+        id: "denom-EXM125-3",
+        meta: {
+          profile: [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note",
+          ],
         },
-        "type": "searchset",
-        "total": 2,
-        "entry": [
-            {
-                "fullUrl": "http://localhost:3000/4_0_1/DiagnosticReport/denom-EXM125-3",
-                "resource": {
-                    "resourceType": "DiagnosticReport",
-                    "id": "denom-EXM125-3",
-                    "meta": {
-                        "profile": [
-                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note"
-                        ]
-                    },
-                }
-            },
-            {
-                "fullUrl": "http://localhost:3000/4_0_1/DiagnosticReport/numer-EXM125-3",
-                "resource": {
-                    "resourceType": "DiagnosticReport",
-                    "id": "numer-EXM125-3",
-                    "meta": {
-                        "profile": [
-                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note"
-                        ]
-                    },
-                }
-            }
-        ]
+      },
+    },
+    {
+      fullUrl: "http://localhost:3000/4_0_1/DiagnosticReport/numer-EXM125-3",
+      resource: {
+        resourceType: "DiagnosticReport",
+        id: "numer-EXM125-3",
+        meta: {
+          profile: [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note",
+          ],
+        },
+      },
+    },
+  ],
 };
 
-const RESOURCE_ID_EMPTY  = {};
+const RESOURCE_ID_EMPTY = {};
 
 describe("resource ID render", () => {
-    beforeAll(() => {
-      global.fetch = getMockFetchImplementation(RESOURCE_ID_BODY);
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementation(RESOURCE_ID_BODY);
+  });
+
+  it("should display all the id's as buttons", async () => {
+    await act(async () => {
+      render(mantineRecoilWrap(<ResourceIDs jsonBody={RESOURCE_ID_BODY}></ResourceIDs>));
     });
-  
-    it("should display all the id's as buttons", async () => {
-      await act(async () => {
-        render(mantineRecoilWrap(<ResourceIDs jsonBody={RESOURCE_ID_BODY}></ResourceIDs>));
-      });
-      
 
-      expect(screen.getByRole("button", { name: "denom-EXM125-3" })).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "numer-EXM125-3" })).toBeInTheDocument();
-
-  }); })
-  
+    expect(screen.getByRole("button", { name: "denom-EXM125-3" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "numer-EXM125-3" })).toBeInTheDocument();
+  });
+});
 
 describe("resource ID empty dataset", () => {
   beforeAll(() => {
     global.fetch = getMockFetchImplementation(RESOURCE_ID_EMPTY);
   });
 
-  it("should display 'no resources of type' on the screen", async () => {
+  it("should display 'no resources found' on the screen", async () => {
     await act(async () => {
       render(mantineRecoilWrap(<ResourceIDs jsonBody={RESOURCE_ID_EMPTY}></ResourceIDs>));
     });
 
-    expect(screen.getByText("No resources of type")).toBeInTheDocument() 
-
-}); })
-
-
+    expect(screen.getByText("No resources found")).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/ResourceId.test.tsx
+++ b/__tests__/components/ResourceId.test.tsx
@@ -55,9 +55,8 @@ describe("resource ID render", () => {
       });
       
 
-      expect(screen.getByRole('button')).toBeInTheDocument();
-      expect(screen.getByText("denom-EXM125-3")).toBeInTheDocument() 
-      expect(screen.getByText("numer-EXM125-3")).toBeInTheDocument() 
+      expect(screen.getByRole("button", { name: "denom-EXM125-3" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "numer-EXM125-3" })).toBeInTheDocument();
 
   }); })
   

--- a/__tests__/components/ResourceId.test.tsx
+++ b/__tests__/components/ResourceId.test.tsx
@@ -7,8 +7,9 @@ import {
 } from "../helpers/testHelpers";
 import ResourceTypeIDs from "../../pages/[resourceType]";
 import { RouterContext } from "next/dist/shared/lib/router-context";
+import { fhirJson } from "@fhir-typescript/r4-core";
 
-const RESOURCE_ID_BODY = {
+const RESOURCE_ID_BODY: fhirJson.Bundle = {
   resourceType: "Bundle",
   meta: {
     lastUpdated: "2022-06-23T19:52:58.721Z",
@@ -69,8 +70,12 @@ describe("resource ID button render", () => {
         </RouterContext.Provider>,
       );
     });
-    expect(await screen.findByRole("button", { name: "denom-EXM125-3" })).toBeInTheDocument();
-    expect(await screen.findByRole("button", { name: "numer-EXM125-3" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: "DiagnosticReport/denom-EXM125-3" }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: "DiagnosticReport/numer-EXM125-3" }),
+    ).toBeInTheDocument();
   });
 });
 

--- a/__tests__/components/ResourceId.test.tsx
+++ b/__tests__/components/ResourceId.test.tsx
@@ -69,8 +69,8 @@ describe("resource ID button render", () => {
         </RouterContext.Provider>,
       );
     });
-    expect(screen.getByRole("button", { name: "denom-EXM125-3" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "numer-EXM125-3" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "denom-EXM125-3" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "numer-EXM125-3" })).toBeInTheDocument();
   });
 });
 
@@ -91,7 +91,7 @@ describe("Tests for when the 'No resource found message' should display", () => 
         </RouterContext.Provider>,
       );
     });
-    expect(screen.getByText("No resources found")).toBeInTheDocument();
+    expect(await screen.findByText("No resources found")).toBeInTheDocument();
   });
 });
 
@@ -113,6 +113,6 @@ describe("error response test", () => {
       );
     });
 
-    expect(screen.getByText("Problem connecting to server")).toBeInTheDocument();
+    expect(await screen.findByText("Problem connecting to server")).toBeInTheDocument();
   });
 });

--- a/__tests__/components/ResourceId.test.tsx
+++ b/__tests__/components/ResourceId.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, act, within } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import {
+  mantineRecoilWrap,
+  getMockFetchImplementation,
+  getMockFetchImplementationError,
+} from "../helpers/testHelpers";
+import ResourceIDs from "../../components/ResourceIDs";
+
+const RESOURCE_ID_BODY  = {
+        "resourceType": "Bundle",
+        "meta": {
+            "lastUpdated": "2022-06-23T19:52:58.721Z"
+        },
+        "type": "searchset",
+        "total": 2,
+        "entry": [
+            {
+                "fullUrl": "http://localhost:3000/4_0_1/DiagnosticReport/denom-EXM125-3",
+                "resource": {
+                    "resourceType": "DiagnosticReport",
+                    "id": "denom-EXM125-3",
+                    "meta": {
+                        "profile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note"
+                        ]
+                    },
+                }
+            },
+            {
+                "fullUrl": "http://localhost:3000/4_0_1/DiagnosticReport/numer-EXM125-3",
+                "resource": {
+                    "resourceType": "DiagnosticReport",
+                    "id": "numer-EXM125-3",
+                    "meta": {
+                        "profile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note"
+                        ]
+                    },
+                }
+            }
+        ]
+};
+
+const RESOURCE_ID_EMPTY  = {};
+
+describe("resource ID render", () => {
+    beforeAll(() => {
+      global.fetch = getMockFetchImplementation(RESOURCE_ID_BODY);
+    });
+  
+    it("should display all the id's as buttons", async () => {
+      await act(async () => {
+        render(mantineRecoilWrap(<ResourceIDs jsonBody={RESOURCE_ID_BODY}></ResourceIDs>));
+      });
+      
+
+      expect(screen.getByRole('button')).toBeInTheDocument();
+      expect(screen.getByText("denom-EXM125-3")).toBeInTheDocument() 
+      expect(screen.getByText("numer-EXM125-3")).toBeInTheDocument() 
+
+  }); })
+  
+
+describe("resource ID empty dataset", () => {
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementation(RESOURCE_ID_EMPTY);
+  });
+
+  it("should display 'no resources of type' on the screen", async () => {
+    await act(async () => {
+      render(mantineRecoilWrap(<ResourceIDs jsonBody={RESOURCE_ID_EMPTY}></ResourceIDs>));
+    });
+
+    expect(screen.getByText("No resources of type")).toBeInTheDocument() 
+
+}); })
+
+

--- a/__tests__/helpers/testHelpers.tsx
+++ b/__tests__/helpers/testHelpers.tsx
@@ -2,6 +2,34 @@
 import { ColorSchemeProvider, MantineProvider } from "@mantine/core";
 import { NotificationsProvider } from "@mantine/notifications";
 import { RecoilRoot } from "recoil";
+import { NextRouter } from "next/router";
+
+export function createMockRouter(router: Partial<NextRouter>): NextRouter {
+  return {
+    basePath: "",
+    pathname: "/",
+    route: "/",
+    query: {},
+    asPath: "/",
+    back: jest.fn(),
+    beforePopState: jest.fn(),
+    prefetch: jest.fn(),
+    push: jest.fn(),
+    reload: jest.fn(),
+    replace: jest.fn(),
+    events: {
+      on: jest.fn(),
+      off: jest.fn(),
+      emit: jest.fn(),
+    },
+    isLocaleDomain: false,
+    isFallback: false,
+    isReady: true,
+    defaultLocale: "en",
+    isPreview: false,
+    ...router,
+  };
+}
 
 export function mantineRecoilWrap(children: JSX.Element) {
   return (

--- a/__tests__/helpers/testHelpers.tsx
+++ b/__tests__/helpers/testHelpers.tsx
@@ -13,8 +13,8 @@ export function createMockRouter(router: Partial<NextRouter>): NextRouter {
     asPath: "/",
     back: jest.fn(),
     beforePopState: jest.fn(),
-    prefetch: jest.fn(),
-    push: jest.fn(),
+    prefetch: jest.fn().mockImplementation(() => Promise.resolve()),
+    push: jest.fn().mockImplementation(() => Promise.resolve(true)),
     reload: jest.fn(),
     replace: jest.fn(),
     events: {

--- a/components/ResourceCounts.tsx
+++ b/components/ResourceCounts.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Badge, Button, Stack } from "@mantine/core";
 import { cleanNotifications, showNotification } from "@mantine/notifications";
+import Link from "next/link";
 
 /**
  * interface for object that is returned from a request to the resourceCunt endpoint.
@@ -42,24 +43,27 @@ const ResourceCounts = () => {
    */
   const getResourceCountsNodes = () => {
     return sortResourceArray(resources).map((resourceType) => (
-      <Button
-        fullWidth
-        compact
-        color="cyan"
-        radius="md"
-        size="md"
-        variant="subtle"
-        styles={{
-          inner: {
-            paddingLeft: "15px",
-            justifyContent: "flex-start",
-          },
-        }}
-        rightIcon={<Badge color="cyan">{resources[resourceType]}</Badge>}
-        key={resourceType}
-      >
-        {resourceType}
-      </Button>
+      <Link href={`/${resourceType}`} key={resourceType} passHref>
+        <Button
+          fullWidth
+          compact
+          component="a"
+          color="cyan"
+          radius="md"
+          size="md"
+          variant="subtle"
+          styles={{
+            inner: {
+              paddingLeft: "15px",
+              justifyContent: "flex-start",
+            },
+          }}
+          rightIcon={<Badge color="cyan">{resources[resourceType]}</Badge>}
+          key={resourceType}
+        >
+          {resourceType}
+        </Button>
+      </Link>
     ));
   };
 

--- a/components/ResourceIDs.tsx
+++ b/components/ResourceIDs.tsx
@@ -1,6 +1,6 @@
+import { fhirJson } from "@fhir-typescript/r4-core";
 import { Button } from "@mantine/core";
 import Link from "next/link";
-import { ResourceTypeResponse, EntryKeyObject } from "./../pages/[resourceType]";
 
 /**
  * Component for displaying resource IDs as Links
@@ -9,30 +9,30 @@ import { ResourceTypeResponse, EntryKeyObject } from "./../pages/[resourceType]"
  * @returns an array of Links of resource IDs, or if none exist, a "No resource found" message, or if an
  * invalid response body is passed through, an error message
  */
-function ResourceIDs(props: { jsonBody: ResourceTypeResponse }) {
+function ResourceIDs(props: { jsonBody: fhirJson.Bundle }) {
   const entryArray = props.jsonBody.entry;
 
   if (props.jsonBody.total === 0) {
     return <div>No resources found</div>;
-  } else if (props.jsonBody.total > 0) {
+  } else if (props.jsonBody.total && props.jsonBody.total > 0) {
     return (
       <div>
-        <h2>Resource IDs:</h2> {getAllIDs(entryArray)}
+        <h2>Resource IDs:</h2>{" "}
+        {entryArray != null ? getAllIDs(entryArray) : <div>No resources</div>}
       </div>
     );
   } else {
-    return <div>Error</div>;
+    return <div>Invalid JSON Body</div>;
   }
 }
-
 /**
  * Maps an array of resource bodies to an array of Link-wrapped-Buttons, where each Button represents a resource ID
  * @param entry which is the entry key from a resource bundle. It is an array where each index is a resource's body
  * @returns an array of Resource ID Link-wrapped-Buttons
  */
-const getAllIDs = (entry: EntryKeyObject[]) => {
+const getAllIDs = (entry: (fhirJson.BundleEntry | null)[]) => {
   return entry.map((el) => {
-    return (
+    return el?.resource ? (
       <Link href={`/`} key={el.resource.id} passHref>
         <div>
           <Button
@@ -44,11 +44,15 @@ const getAllIDs = (entry: EntryKeyObject[]) => {
               padding: "2px",
             }}
           >
-            <div> {el.resource.id} </div>
+            <div>
+              {" "}
+              {el.resource.resourceType}/{el.resource.id}{" "}
+            </div>
           </Button>
-          {"\n"}
         </div>
       </Link>
+    ) : (
+      <div>Something went wrong</div>
     );
   });
 };

--- a/components/ResourceIDs.tsx
+++ b/components/ResourceIDs.tsx
@@ -6,23 +6,32 @@ import { ResourceTypeResponse, EntryKeyObject } from "./../pages/[resourceType]"
  * Component for displaying resource IDs as Links
  * @param props include jsonBody which is the response from a GET request to
  * a resourceType endpoint.
- * @returns an array of Links of resource IDs, or if none exist, a "No resource found" message
+ * @returns an array of Links of resource IDs, or if none exist, a "No resource found" message, or if an
+ * invalid response body is passed through, an error message
  */
 function ResourceIDs(props: { jsonBody: ResourceTypeResponse }) {
   const entryArray = props.jsonBody.entry;
 
-  if (entryArray) {
-    return (
-      <div>
-        <h2>Resource IDs:</h2> {getAllIDs(entryArray)}
-      </div>
-    );
+  if (props.jsonBody.total >= 0) {
+    if (props.jsonBody.total > 0) {
+      return (
+        <div>
+          <h2>Resource IDs:</h2> {getAllIDs(entryArray)}
+        </div>
+      );
+    } else {
+      return <div>No resources found</div>;
+    }
   } else {
-    return <div>No resources found</div>;
+    return <div>Problem connecting to server</div>;
   }
 }
 
-//maps each element in entry, an array of all the resources of a resourceType, to a Link
+/**
+ * Maps an array of resource bodies to an array of Link-wrapped-Buttons, where each Button represents a resource ID
+ * @param entry which is the entry key from a resource bundle. It is an array where each index is a resource's body
+ * @returns an array of Resource ID Link-wrapped-Buttons
+ */
 const getAllIDs = (entry: EntryKeyObject[]) => {
   return entry.map((el) => {
     return (

--- a/components/ResourceIDs.tsx
+++ b/components/ResourceIDs.tsx
@@ -1,0 +1,44 @@
+import { Button } from "@mantine/core";
+import Link from "next/link";
+
+/*
+    props: jsonbody of get resourceType request
+*/
+function ResourceIDs(props) {
+  const entryArray = props.jsonBody.entry;
+  console.log(props.jsonBody);
+  if (entryArray) {
+    return (
+      <div>
+        <h2>Resource IDs:</h2> {getAllIDs(entryArray)}
+      </div>
+    );
+  } else {
+    return <div>No resources of type {props.jso} </div>;
+  }
+}
+
+const getAllIDs = (entry) => {
+  return entry.map((el) => {
+    return (
+      <Link href={`/`} key={el.resource.id} passHref>
+        <div>
+          <Button
+            color="cyan"
+            radius="md"
+            size="md"
+            variant="subtle"
+            style={{
+              padding: "2px",
+            }}
+          >
+            <div> {el.resource.id} </div>
+          </Button>
+          {"\n"}
+        </div>
+      </Link>
+    );
+  });
+};
+
+export default ResourceIDs;

--- a/components/ResourceIDs.tsx
+++ b/components/ResourceIDs.tsx
@@ -1,12 +1,15 @@
 import { Button } from "@mantine/core";
 import Link from "next/link";
+import { ReactElement, JSXElementConstructor, ReactFragment, ReactPortal } from "react";
+import { ResourceTypeResponse, EntryKeyObject } from "./../pages/[resourceType]";
 
 /*
     props: jsonbody of get resourceType request
 */
-function ResourceIDs(props) {
+function ResourceIDs(props: { jsonBody: ResourceTypeResponse }) {
+  //props: { jsonBody: { entry: any; }; jso: string | number | boolean | ReactElement<any, string | JSXElementConstructor<any>> | ReactFragment | ReactPortal | null | undefined; }) {
   const entryArray = props.jsonBody.entry;
-  console.log(props.jsonBody);
+  console.log("jsonBody.entry: ", props.jsonBody.entry);
   if (entryArray) {
     return (
       <div>
@@ -14,11 +17,11 @@ function ResourceIDs(props) {
       </div>
     );
   } else {
-    return <div>No resources of type {props.jso} </div>;
+    return <div>No resources of type </div>;
   }
 }
 
-const getAllIDs = (entry) => {
+const getAllIDs = (entry: EntryKeyObject[]) => {
   return entry.map((el) => {
     return (
       <Link href={`/`} key={el.resource.id} passHref>

--- a/components/ResourceIDs.tsx
+++ b/components/ResourceIDs.tsx
@@ -12,18 +12,16 @@ import { ResourceTypeResponse, EntryKeyObject } from "./../pages/[resourceType]"
 function ResourceIDs(props: { jsonBody: ResourceTypeResponse }) {
   const entryArray = props.jsonBody.entry;
 
-  if (props.jsonBody.total >= 0) {
-    if (props.jsonBody.total > 0) {
-      return (
-        <div>
-          <h2>Resource IDs:</h2> {getAllIDs(entryArray)}
-        </div>
-      );
-    } else {
-      return <div>No resources found</div>;
-    }
+  if (props.jsonBody.total === 0) {
+    return <div>No resources found</div>;
+  } else if (props.jsonBody.total > 0) {
+    return (
+      <div>
+        <h2>Resource IDs:</h2> {getAllIDs(entryArray)}
+      </div>
+    );
   } else {
-    return <div>Problem connecting to server</div>;
+    return <div>Error</div>;
   }
 }
 

--- a/components/ResourceIDs.tsx
+++ b/components/ResourceIDs.tsx
@@ -1,15 +1,16 @@
 import { Button } from "@mantine/core";
 import Link from "next/link";
-import { ReactElement, JSXElementConstructor, ReactFragment, ReactPortal } from "react";
 import { ResourceTypeResponse, EntryKeyObject } from "./../pages/[resourceType]";
 
-/*
-    props: jsonbody of get resourceType request
-*/
+/**
+ * Component for displaying resource IDs as Links
+ * @param props include jsonBody which is the response from a GET request to
+ * a resourceType endpoint.
+ * @returns an array of Links of resource IDs, or if none exist, a "No resource found" message
+ */
 function ResourceIDs(props: { jsonBody: ResourceTypeResponse }) {
-  //props: { jsonBody: { entry: any; }; jso: string | number | boolean | ReactElement<any, string | JSXElementConstructor<any>> | ReactFragment | ReactPortal | null | undefined; }) {
   const entryArray = props.jsonBody.entry;
-  console.log("jsonBody.entry: ", props.jsonBody.entry);
+
   if (entryArray) {
     return (
       <div>
@@ -17,10 +18,11 @@ function ResourceIDs(props: { jsonBody: ResourceTypeResponse }) {
       </div>
     );
   } else {
-    return <div>No resources of type </div>;
+    return <div>No resources found</div>;
   }
 }
 
+//maps each element in entry, an array of all the resources of a resourceType, to a Link
 const getAllIDs = (entry: EntryKeyObject[]) => {
   return entry.map((el) => {
     return (

--- a/components/ResourceIDs.tsx
+++ b/components/ResourceIDs.tsx
@@ -17,7 +17,7 @@ function ResourceIDs(props: { jsonBody: fhirJson.Bundle }) {
   } else if (props.jsonBody.total && props.jsonBody.total > 0) {
     return (
       <div>
-        <h2>Resource IDs:</h2>{" "}
+        <h2>Resource IDs:</h2>
         {entryArray != null ? getAllIDs(entryArray) : <div>No resources</div>}
       </div>
     );
@@ -45,8 +45,7 @@ const getAllIDs = (entry: (fhirJson.BundleEntry | null)[]) => {
             }}
           >
             <div>
-              {" "}
-              {el.resource.resourceType}/{el.resource.id}{" "}
+              {el.resource.resourceType}/{el.resource.id}
             </div>
           </Button>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3372,6 +3372,14 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "requires": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -4968,6 +4976,23 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
       "integrity": "sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw=="
+    },
+    "react-router": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "requires": {
+        "history": "^5.2.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "requires": {
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
+      }
     },
     "react-textarea-autosize": {
       "version": "8.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -566,6 +566,11 @@
         "strip-json-comments": "^3.1.1"
       }
     },
+    "@fhir-typescript/r4-core": {
+      "version": "0.0.12-beta.11",
+      "resolved": "https://registry.npmjs.org/@fhir-typescript/r4-core/-/r4-core-0.0.12-beta.11.tgz",
+      "integrity": "sha512-OfrNU/FTtfxS1vMLJEYVNGwDKOTYP9edvL0ZGPKdeL+q30JQMBpuIuD2uCSZEOtkmXYSh116sqg06QlmViQNAw=="
+    },
     "@humanwhocodes/config-array": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
@@ -3372,14 +3377,6 @@
         "has-symbols": "^1.0.2"
       }
     },
-    "history": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
-      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
-      "requires": {
-        "@babel/runtime": "^7.7.6"
-      }
-    },
     "hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -4976,23 +4973,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
       "integrity": "sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw=="
-    },
-    "react-router": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
-      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
-      "requires": {
-        "history": "^5.2.0"
-      }
-    },
-    "react-router-dom": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
-      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
-      "requires": {
-        "history": "^5.2.0",
-        "react-router": "6.3.0"
-      }
     },
     "react-textarea-autosize": {
       "version": "8.3.4",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@fhir-typescript/r4-core": "0.0.12-beta.11",
     "@mantine/core": "^4.2.4",
     "@mantine/hooks": "^4.2.4",
     "@mantine/next": "^4.2.4",

--- a/pages/[resourceType].tsx
+++ b/pages/[resourceType].tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+import { Button } from "@mantine/core";
+import ResourcePage from "./../components/ResourcePage";
+import { useRouter } from "next/router";
+import ResourceIDs from "../components/ResourceIDs";
+
+function ResourceTypeIDs() {
+  const router = useRouter();
+  const { resourceType } = router.query;
+
+  const [pageBody, setPageBody] = useState("");
+  useEffect(() => {
+    fetch(`${process.env.NEXT_PUBLIC_DEQM_SERVER}/${resourceType}`)
+      .then((data) => {
+        return data.json();
+      })
+      .then((resourcePageBody) => {
+        setPageBody(resourcePageBody); //resourcePageBody["entry"][0].resource.id
+      });
+  }, [resourceType]);
+
+  //return <div>{JSON.stringify(pageBody)}</div>;
+  console.log(pageBody);
+  return pageBody ? <ResourceIDs jsonBody={pageBody}></ResourceIDs> : null;
+}
+export default ResourceTypeIDs;

--- a/pages/[resourceType].tsx
+++ b/pages/[resourceType].tsx
@@ -4,15 +4,31 @@ import ResourcePage from "./../components/ResourcePage";
 import { useRouter } from "next/router";
 import ResourceIDs from "../components/ResourceIDs";
 
+/**
+ * interface for the response body of a request to a resourceType endpoint
+ * Includes a key with a value that is an array of EntryKeyObjects
+ */
+export interface ResourceTypeResponse {
+  [responseAttribute: string]: EntryKeyObject[];
+}
+
+/**
+ * interface for the contents of the "entry" key in a resourceType bundle JSON object.
+ * Includes a resource key with a value that is the id of a resource
+ */
+export interface EntryKeyObject {
+  resource: { id: string };
+}
+
 function ResourceTypeIDs() {
   const router = useRouter();
   const { resourceType } = router.query;
 
-  const [pageBody, setPageBody] = useState("");
+  const [pageBody, setPageBody] = useState<ResourceTypeResponse>({});
   useEffect(() => {
     fetch(`${process.env.NEXT_PUBLIC_DEQM_SERVER}/${resourceType}`)
       .then((data) => {
-        return data.json();
+        return data.json() as Promise<ResourceTypeResponse>;
       })
       .then((resourcePageBody) => {
         setPageBody(resourcePageBody); //resourcePageBody["entry"][0].resource.id
@@ -20,7 +36,7 @@ function ResourceTypeIDs() {
   }, [resourceType]);
 
   //return <div>{JSON.stringify(pageBody)}</div>;
-  console.log(pageBody);
+  console.log("pageBody: ", pageBody);
   return pageBody ? <ResourceIDs jsonBody={pageBody}></ResourceIDs> : null;
 }
 export default ResourceTypeIDs;

--- a/pages/[resourceType].tsx
+++ b/pages/[resourceType].tsx
@@ -7,7 +7,9 @@ import ResourceIDs from "../components/ResourceIDs";
  * Includes a key with a value that is an array of EntryKeyObjects
  */
 export interface ResourceTypeResponse {
-  [responseAttribute: string]: EntryKeyObject[];
+  [responseAttribute: string]: number | EntryKeyObject[];
+  total: number;
+  entry: EntryKeyObject[];
 }
 
 /**
@@ -15,13 +17,14 @@ export interface ResourceTypeResponse {
  * Includes a resource key with a value that is the id of a resource
  */
 export interface EntryKeyObject {
-  resource: { id: string };
+  [resource: string]: { id: string };
 }
 
 /**
  * Component page that renders Buttons for all IDs of a resourceType. A request is made to
  * the test server to retrieve all resources of a specified type. Then a ResourceID component is
- * returned with the Buttons for each resourceID or a "No resources found" message is displayed
+ * returned with the Buttons for each resourceID or a "No resources found" message is displayed, or if
+ * the request to the server throws an error then a "Problem connecting to server" message is displayed
  * @returns
  */
 function ResourceTypeIDs() {
@@ -29,7 +32,7 @@ function ResourceTypeIDs() {
   const router = useRouter();
   const { resourceType } = router.query;
 
-  const [pageBody, setPageBody] = useState<ResourceTypeResponse>({});
+  const [pageBody, setPageBody] = useState<ResourceTypeResponse>();
   useEffect(() => {
     fetch(`${process.env.NEXT_PUBLIC_DEQM_SERVER}/${resourceType}`)
       .then((data) => {
@@ -37,9 +40,12 @@ function ResourceTypeIDs() {
       })
       .then((resourcePageBody) => {
         setPageBody(resourcePageBody);
+      })
+      .catch((error) => {
+        console.log(error.message);
+        setPageBody({ entry: [], total: -1 });
       });
   }, [resourceType]);
-
   return pageBody ? <ResourceIDs jsonBody={pageBody}></ResourceIDs> : null;
 }
 export default ResourceTypeIDs;

--- a/pages/[resourceType].tsx
+++ b/pages/[resourceType].tsx
@@ -2,24 +2,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import ResourceIDs from "../components/ResourceIDs";
 import { Center, Loader } from "@mantine/core";
-
-/**
- * interface for the response body of a request to a resourceType endpoint
- * Includes a key with a value that is an array of EntryKeyObjects
- */
-export interface ResourceTypeResponse {
-  [responseAttribute: string]: number | EntryKeyObject[];
-  total: number;
-  entry: EntryKeyObject[];
-}
-
-/**
- * interface for the contents of the "entry" key in a resourceType bundle JSON object.
- * Includes a resource key with a value that is the id of a resource
- */
-export interface EntryKeyObject {
-  [resource: string]: { id: string };
-}
+import { fhirJson } from "@fhir-typescript/r4-core";
 
 /**
  * Component page that renders Buttons for all IDs of a resourceType. A request is made to
@@ -34,15 +17,15 @@ function ResourceTypeIDs() {
   const router = useRouter();
   const { resourceType } = router.query;
 
-  const [pageBody, setPageBody] = useState<ResourceTypeResponse>();
+  const [pageBody, setPageBody] = useState<fhirJson.Bundle>();
   const [fetchingError, setFetchingError] = useState(false);
   const [loadingRequest, setLoadingRequest] = useState(false);
   useEffect(() => {
     if (resourceType) {
+      setLoadingRequest(true);
       fetch(`${process.env.NEXT_PUBLIC_DEQM_SERVER}/${resourceType}`)
         .then((data) => {
-          setLoadingRequest(true);
-          return data.json() as Promise<ResourceTypeResponse>;
+          return data.json() as Promise<fhirJson.Bundle>;
         })
         .then((resourcePageBody) => {
           setPageBody(resourcePageBody);

--- a/pages/[resourceType].tsx
+++ b/pages/[resourceType].tsx
@@ -1,6 +1,4 @@
 import { useEffect, useState } from "react";
-import { Button } from "@mantine/core";
-import ResourcePage from "./../components/ResourcePage";
 import { useRouter } from "next/router";
 import ResourceIDs from "../components/ResourceIDs";
 
@@ -20,7 +18,14 @@ export interface EntryKeyObject {
   resource: { id: string };
 }
 
+/**
+ * Component page that renders Buttons for all IDs of a resourceType. A request is made to
+ * the test server to retrieve all resources of a specified type. Then a ResourceID component is
+ * returned with the Buttons for each resourceID or a "No resources found" message is displayed
+ * @returns
+ */
 function ResourceTypeIDs() {
+  //get resourceType from the current url with useRouter
   const router = useRouter();
   const { resourceType } = router.query;
 
@@ -31,12 +36,10 @@ function ResourceTypeIDs() {
         return data.json() as Promise<ResourceTypeResponse>;
       })
       .then((resourcePageBody) => {
-        setPageBody(resourcePageBody); //resourcePageBody["entry"][0].resource.id
+        setPageBody(resourcePageBody);
       });
   }, [resourceType]);
 
-  //return <div>{JSON.stringify(pageBody)}</div>;
-  console.log("pageBody: ", pageBody);
   return pageBody ? <ResourceIDs jsonBody={pageBody}></ResourceIDs> : null;
 }
 export default ResourceTypeIDs;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -38,7 +38,7 @@ export default function App(props: AppProps) {
             }
             styles={(theme) => ({
               main: {
-                backgroundColor: theme.colors.cyan[0],
+                backgroundColor: theme.colors.gray[0],
               },
             })}
           >

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,6 +3,7 @@ import Head from "next/head";
 import { AppShell, Header, MantineProvider, Navbar, ScrollArea } from "@mantine/core";
 import { NotificationsProvider } from "@mantine/notifications";
 import { ResourceCounts } from "../components/ResourceCounts";
+import ResourceIDs from "../components/ResourceIDs";
 
 export default function App(props: AppProps) {
   const { Component, pageProps } = props;
@@ -38,8 +39,8 @@ export default function App(props: AppProps) {
             }
             styles={(theme) => ({
               main: {
-                backgroundColor:
-                  theme.colorScheme === "dark" ? theme.colors.dark[8] : theme.colors.gray[0],
+                backgroundColor: theme.colors.cyan[0],
+                //theme.colorScheme === "dark" ? theme.colors.dark[8] : theme.colors.gray[0],
               },
             })}
           >

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,7 +3,6 @@ import Head from "next/head";
 import { AppShell, Header, MantineProvider, Navbar, ScrollArea } from "@mantine/core";
 import { NotificationsProvider } from "@mantine/notifications";
 import { ResourceCounts } from "../components/ResourceCounts";
-import ResourceIDs from "../components/ResourceIDs";
 
 export default function App(props: AppProps) {
   const { Component, pageProps } = props;
@@ -40,7 +39,6 @@ export default function App(props: AppProps) {
             styles={(theme) => ({
               main: {
                 backgroundColor: theme.colors.cyan[0],
-                //theme.colorScheme === "dark" ? theme.colors.dark[8] : theme.colors.gray[0],
               },
             })}
           >


### PR DESCRIPTION
# Summary
- Renders resource ID buttons on main page body when a resource count button in the navigation bar is clicked. 
- A “No resources found” message is displayed when a resource with a count of 0 is clicked. 
- A "Problem connecting to server" message is displayed if there is an issue making a request to the server when a resource count button is clicked.

## New behavior

- Resource count buttons in navigation bar now cause resource ID buttons or a “No resources found” message to be displayed when clicked

## Code changes 

- pages/[resourceType].tsx added which is the “page” that displays when a resource count button is clicked in the navigation bar
- components/ResourceIDs.tsx added which is the component for rendering resourceID buttons or an "error" message
- tests/components/ResourceId.test.tsx added which tests that resource ID buttons or the appropriate "error" message appears when a resource count button is clicked
- tests/components/ResourceCounts.test.tsx tests updated because they are now Link-wrapped-Buttons (used to be just Buttons)

## Testing guidance

- Have a .env.local file and add the following to it: `NEXT_PUBLIC_DEQM_SERVER=https://abacus-dev.mitre.org/4_0_1` However, to run a local version of the test server, change this `NEXT_PUBLIC_DEQM_SERVER` to the desired port (this project runs on the default 3000).
- Run unit tests with `npm run test`
- run the frontend w `npm run dev`, then navigate to [http://localhost:3000](http://localhost:3000). Click on any of the resource count buttons in the navigation bar and clickable resource ID buttons should appear in the main page body for any resource with a count of >=1. For resources with a count of 0, a “No resource found” message should appear in the main page body. 
- To test the server connection error message, load the home page, disconnect from the server, then click on any of the resource count buttons. A "Problem connecting to server" message should appear in the main page body.