### PR TITLE
Create resource unit testing

### DIFF
--- a/__tests__/helpers/testHelpers.tsx
+++ b/__tests__/helpers/testHelpers.tsx
@@ -54,17 +54,20 @@ export function mantineRecoilWrap(children: JSX.Element) {
  * @param desiredResponse is the response that the returned Promise is resolved to
  * @param desiredStatus optional, for specifying the status code. Default is 200
  * @param desiredStatusText optional, for specifying the status text
+ * @param desiredHeaders optional, for specifying the header. Must be of type Headers
  */
 export function getMockFetchImplementation(
   desiredResponse: any,
   desiredStatus?: number,
   desiredStatusText?: string,
+  desiredHeaders?: Headers,
 ) {
   return jest.fn(() => {
     return Promise.resolve({
       json: jest.fn().mockResolvedValue(desiredResponse),
       status: desiredStatus ? desiredStatus : 200,
       statusText: desiredStatusText,
+      headers: desiredHeaders,
     }) as any;
   });
 }

--- a/__tests__/helpers/testHelpers.tsx
+++ b/__tests__/helpers/testHelpers.tsx
@@ -58,14 +58,14 @@ export function mantineRecoilWrap(children: JSX.Element) {
  */
 export function getMockFetchImplementation(
   desiredResponse: any,
-  desiredStatus?: number,
+  desiredStatus = 200,
   desiredStatusText?: string,
   desiredHeaders?: Headers,
 ) {
   return jest.fn(() => {
     return Promise.resolve({
       json: jest.fn().mockResolvedValue(desiredResponse),
-      status: desiredStatus ? desiredStatus : 200,
+      status: desiredStatus,
       statusText: desiredStatusText,
       headers: desiredHeaders,
     }) as any;

--- a/__tests__/pages/resource/create.test.tsx
+++ b/__tests__/pages/resource/create.test.tsx
@@ -7,10 +7,13 @@ import {
   createMockRouter,
   getMockFetchImplementationError,
   createRectRange,
+  getMockFetchImplementation,
 } from "../../helpers/testHelpers";
 import userEvent from "@testing-library/user-event";
 
-describe.skip("create new resource page render", () => {
+const ERROR_400_RESPONSE_BODY = { issue: [{ details: { text: "Invalid resource body" } }] };
+
+describe("Create new resource page render", () => {
   it("should display a code editor component, submit resource button, and a back button", async () => {
     await act(async () => {
       render(
@@ -23,19 +26,106 @@ describe.skip("create new resource page render", () => {
         </RouterContext.Provider>,
       );
     });
-    expect(await screen.findByTestId("back-button")).toBeInTheDocument();
-    expect(await screen.findByRole("button", { name: "Submit Resource" })).toBeInTheDocument();
-    expect(await screen.findByTestId("resource-code-editor")).toBeInTheDocument();
+    expect(screen.getByTestId("back-button")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Submit Resource" })).toBeInTheDocument();
+    expect(screen.getByTestId("resource-code-editor")).toBeInTheDocument();
   });
 });
 
-describe("error response test", () => {
+describe("Successful resource creation", () => {
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementation(
+      "",
+      200,
+      "Resource created!!",
+      new Headers({ Location: "4_0_1/DiagnosticReport/123456789" }),
+    );
+    document.createRange = createRectRange;
+  });
+
+  it("Test for success notification", async () => {
+    const user = userEvent.setup();
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <RouterContext.Provider
+            value={createMockRouter({
+              query: { resourceType: "DiagnosticReport" },
+            })}
+          >
+            <CreateResourcePage />
+          </RouterContext.Provider>,
+        ),
+      );
+    });
+
+    const submitButton = screen.getByRole("button", {
+      name: "Submit Resource",
+    }) as HTMLButtonElement;
+
+    const codeEditor = screen.getByRole("textbox");
+
+    //CodeMirror autocloses brackets, so only one is necessary to type
+    user.type(codeEditor, "{{").finally(() => {
+      //await user.Type Promise to resolve/reject before clicking the submit button
+      user.click(submitButton);
+    });
+
+    const errorNotif = (await screen.findByRole("alert")) as HTMLDivElement;
+    expect(errorNotif).toBeInTheDocument();
+
+    expect(within(errorNotif).getByText(/Resource successfully created:/)).toBeInTheDocument();
+    expect(within(errorNotif).getByText(/DiagnosticReport\/123456789/)).toBeInTheDocument();
+  });
+});
+
+describe("Invalid resource creation", () => {
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementation(ERROR_400_RESPONSE_BODY, 400, "Bad Request");
+    document.createRange = createRectRange;
+  });
+
+  it("Test for error notification for 400 response", async () => {
+    const user = userEvent.setup();
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <RouterContext.Provider
+            value={createMockRouter({
+              query: { resourceType: "DiagnosticReport" },
+            })}
+          >
+            <CreateResourcePage />
+          </RouterContext.Provider>,
+        ),
+      );
+    });
+
+    const submitButton = screen.getByRole("button", {
+      name: "Submit Resource",
+    }) as HTMLButtonElement;
+
+    const codeEditor = screen.getByRole("textbox");
+
+    user.type(codeEditor, "{{").finally(() => {
+      user.click(submitButton);
+    });
+
+    const errorNotif = (await screen.findByRole("alert")) as HTMLDivElement;
+    expect(errorNotif).toBeInTheDocument();
+
+    expect(within(errorNotif).getByText(/400 Bad Request/)).toBeInTheDocument();
+    expect(within(errorNotif).getByText(/Invalid resource body/)).toBeInTheDocument();
+  });
+});
+
+describe("Error thrown during create test", () => {
   beforeAll(() => {
     global.fetch = getMockFetchImplementationError("400 Bad Request");
     document.createRange = createRectRange;
   });
 
-  it("should show error notification when not connected to server", async () => {
+  it("Test for error notification when error is thrown", async () => {
     const user = userEvent.setup();
     await act(async () => {
       render(
@@ -57,15 +147,7 @@ describe("error response test", () => {
 
     const codeEditor = screen.getByRole("textbox");
 
-    await act(async () => {
-      user.type(codeEditor, "{{");
-    });
-
-    const doneTyping = new Promise((resolve, reject) => {
-      setTimeout(() => resolve("value"), 500);
-    });
-    doneTyping.finally(() => {
-      console.log("clicking button");
+    user.type(codeEditor, "{{").finally(() => {
       user.click(submitButton);
     });
 

--- a/__tests__/pages/resource/create.test.tsx
+++ b/__tests__/pages/resource/create.test.tsx
@@ -66,10 +66,8 @@ describe("Successful resource creation", () => {
     const codeEditor = screen.getByRole("textbox");
 
     //CodeMirror autocloses brackets, so only one is necessary to type
-    user.type(codeEditor, "{{").finally(() => {
-      //await user.Type Promise to resolve/reject before clicking the submit button
-      user.click(submitButton);
-    });
+    await user.type(codeEditor, "{{");
+    user.click(submitButton);
 
     const errorNotif = (await screen.findByRole("alert")) as HTMLDivElement;
     expect(errorNotif).toBeInTheDocument();
@@ -107,9 +105,8 @@ describe("Invalid resource creation", () => {
 
     const codeEditor = screen.getByRole("textbox");
 
-    user.type(codeEditor, "{{").finally(() => {
-      user.click(submitButton);
-    });
+    await user.type(codeEditor, "{{");
+    user.click(submitButton);
 
     const errorNotif = (await screen.findByRole("alert")) as HTMLDivElement;
     expect(errorNotif).toBeInTheDocument();
@@ -147,9 +144,8 @@ describe("Error thrown during create test", () => {
 
     const codeEditor = screen.getByRole("textbox");
 
-    user.type(codeEditor, "{{").finally(() => {
-      user.click(submitButton);
-    });
+    await user.type(codeEditor, "{{");
+    user.click(submitButton);
 
     const errorNotif = (await screen.findByRole("alert")) as HTMLDivElement;
     expect(errorNotif).toBeInTheDocument();

--- a/components/ResourceCodeEditor.tsx
+++ b/components/ResourceCodeEditor.tsx
@@ -27,7 +27,7 @@ const ResourceCodeEditor = (props: ResourceCodeEditorProps) => {
     <CodeMirror
       data-testid="resource-code-editor"
       value={props.initialValue}
-      height="80vh"
+      height="78vh"
       extensions={[json(), linter(jsonLinter)]}
       onUpdate={(v) => {
         if (props.onValidate) {


### PR DESCRIPTION
## Summary 
Unit tests for create resource request implementation have been revised and added. 

## New behavior
Only unit tests were added.

## Code Changes
- **tests/pages/resource/create.test.tsx** includes 3 new unit tests, and one that was being skipped has been revised
- **tests/helpers/testHelpers.tsx** getMockFetchImplementation function updated to allow for more types of fetch responses, createRectRange added to prevent text range errors being thrown while testing CodeMirror

## Testing
- see `README.md` for first time test server set up
- Run the new unit tests: `npm run test `