### PR TITLE
Delete resource

### DIFF
--- a/__tests__/pages/resource/id/index.test.tsx
+++ b/__tests__/pages/resource/id/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import {
   getMockFetchImplementation,
@@ -16,7 +16,7 @@ const SINGLE_RESOURCE_BODY = {
   },
 };
 
-describe("resource ID render", () => {
+describe.only("resource ID render", () => {
   window.ResizeObserver = mockResizeObserver;
   beforeAll(() => {
     global.fetch = getMockFetchImplementation(SINGLE_RESOURCE_BODY);
@@ -39,6 +39,7 @@ describe("resource ID render", () => {
     expect(await screen.findByTestId("back-button")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Update" })).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Evaluate Measure" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
 
     //parses out relevant information from the Prism HTML block and stores it in an array
     const spanText = [""];
@@ -59,6 +60,21 @@ describe("resource ID render", () => {
         '"http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note"',
       ),
     ).toBe(true);
+
+    const deleteButton = screen.getByRole("button", {
+      name: "Delete",
+
+    }) as HTMLButtonElement;
+    // fireEvent.click(deleteButton);
+    const mypromise = new Promise((resolve, reject) => setTimeout("3000"));
+    mypromise.finally(() => {fireEvent.click(deleteButton);})
+
+    const errorNotif = (await screen.findByTitle("Delete Resource!!!!!"));
+    expect(errorNotif).toBeInTheDocument();
+    // screen.debug()
+
+    // expect(within(errorNotif).getByText(/Resource successfully updated!/)).toBeInTheDocument();
+
   });
 });
 

--- a/__tests__/pages/resource/id/index.test.tsx
+++ b/__tests__/pages/resource/id/index.test.tsx
@@ -16,7 +16,7 @@ const SINGLE_RESOURCE_BODY = {
   },
 };
 
-describe.only("resource ID render", () => {
+describe("resource ID render", () => {
   window.ResizeObserver = mockResizeObserver;
   beforeAll(() => {
     global.fetch = getMockFetchImplementation(SINGLE_RESOURCE_BODY);

--- a/__tests__/pages/resource/id/index.test.tsx
+++ b/__tests__/pages/resource/id/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act, fireEvent } from "@testing-library/react";
+import { render, screen, act, fireEvent, within } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import {
   getMockFetchImplementation,
@@ -63,18 +63,18 @@ describe.only("resource ID render", () => {
 
     const deleteButton = screen.getByRole("button", {
       name: "Delete",
-
     }) as HTMLButtonElement;
-    // fireEvent.click(deleteButton);
-    const mypromise = new Promise((resolve, reject) => setTimeout("3000"));
-    mypromise.finally(() => {fireEvent.click(deleteButton);})
 
-    const errorNotif = (await screen.findByTitle("Delete Resource!!!!!"));
-    expect(errorNotif).toBeInTheDocument();
-    // screen.debug()
+    // click the identified delete button
+    fireEvent.click(deleteButton);
 
-    // expect(within(errorNotif).getByText(/Resource successfully updated!/)).toBeInTheDocument();
-
+    //make sure a modal with the correct information shows up. Mantine modals are classified as dialogs.
+    const deleteModal = await screen.findByRole("dialog");
+    expect(deleteModal).toBeInTheDocument();
+    expect(within(deleteModal).getByText(/DiagnosticReport/)).toBeInTheDocument();
+    expect(within(deleteModal).getByText(/denom-EXM125-3/)).toBeInTheDocument();
+    expect(within(deleteModal).getByRole("button", { name: "Delete" })).toBeInTheDocument();
+    expect(within(deleteModal).getByRole("button", { name: "Cancel" })).toBeInTheDocument();
   });
 });
 

--- a/__tests__/pages/resource/id/index.test.tsx
+++ b/__tests__/pages/resource/id/index.test.tsx
@@ -22,7 +22,7 @@ describe("resource ID render", () => {
     global.fetch = getMockFetchImplementation(SINGLE_RESOURCE_BODY);
   });
 
-  it("should display the JSON content of a single resource, a back button, and an update button", async () => {
+  it("should display the back-button, update-button, and delete-button", async () => {
     await act(async () => {
       render(
         <RouterContext.Provider
@@ -40,6 +40,20 @@ describe("resource ID render", () => {
     expect(screen.getByRole("link", { name: "Update" })).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Evaluate Measure" })).toBeNull();
     expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+  });
+
+  it("should display the JSON content of a single resource", async () => {
+    await act(async () => {
+      render(
+        <RouterContext.Provider
+          value={createMockRouter({
+            query: { resourceType: "DiagnosticReport", id: "denom-EXM125-3" },
+          })}
+        >
+          <ResourceIDPage />
+        </RouterContext.Provider>,
+      );
+    });
 
     //parses out relevant information from the Prism HTML block and stores it in an array
     const spanText = [""];
@@ -60,6 +74,20 @@ describe("resource ID render", () => {
         '"http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note"',
       ),
     ).toBe(true);
+  });
+
+  it("should display the delete modal when the delete button is pressed", async () => {
+    await act(async () => {
+      render(
+        <RouterContext.Provider
+          value={createMockRouter({
+            query: { resourceType: "DiagnosticReport", id: "denom-EXM125-3" },
+          })}
+        >
+          <ResourceIDPage />
+        </RouterContext.Provider>,
+      );
+    });
 
     const deleteButton = screen.getByRole("button", {
       name: "Delete",

--- a/__tests__/pages/resource/id/index.test.tsx
+++ b/__tests__/pages/resource/id/index.test.tsx
@@ -16,6 +16,31 @@ const SINGLE_RESOURCE_BODY = {
   },
 };
 
+describe("measure resource ID render", () => {
+  window.ResizeObserver = mockResizeObserver;
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementation("");
+  });
+
+  it("should display an evaluate measure button", async () => {
+    await act(async () => {
+      render(
+        <RouterContext.Provider
+          value={createMockRouter({
+            query: { resourceType: "Measure", id: "Measure12" },
+          })}
+        >
+          <ResourceIDPage />
+        </RouterContext.Provider>,
+      );
+    });
+
+    //for Measure resources, an additional button named "Evaluate Measure" will be in the document
+    // expect(await screen.findByRole("button", { name: "Evaluate Measure" })).toBeInTheDocument();
+    expect(await screen.findByRole("link", { name: "Evaluate Measure" })).toBeInTheDocument();
+  });
+});
+
 describe("resource ID render", () => {
   window.ResizeObserver = mockResizeObserver;
   beforeAll(() => {
@@ -103,28 +128,5 @@ describe("resource ID render", () => {
     expect(within(deleteModal).getByText(/denom-EXM125-3/)).toBeInTheDocument();
     expect(within(deleteModal).getByRole("button", { name: "Delete" })).toBeInTheDocument();
     expect(within(deleteModal).getByRole("button", { name: "Cancel" })).toBeInTheDocument();
-  });
-});
-
-describe("measure resource ID render", () => {
-  beforeAll(() => {
-    global.fetch = getMockFetchImplementation("");
-  });
-
-  it("should display an evaluate measure button", async () => {
-    await act(async () => {
-      render(
-        <RouterContext.Provider
-          value={createMockRouter({
-            query: { resourceType: "Measure", id: "Measure12" },
-          })}
-        >
-          <ResourceIDPage />
-        </RouterContext.Provider>,
-      );
-    });
-
-    //for Measure resources, an additional button named "Evaluate Measure" will be in the document
-    expect(screen.getByRole("link", { name: "Evaluate Measure" })).toBeInTheDocument();
   });
 });

--- a/components/DeleteButton.tsx
+++ b/components/DeleteButton.tsx
@@ -10,7 +10,6 @@ import { useModals } from "@mantine/modals";
  * wants to delete the resource. Only deletes if the user confirms, cancels otherwise.
  */
 export default function DeleteButton() {
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const router = useRouter();
   const modals = useModals();
   const { resourceType, id } = router.query;
@@ -29,7 +28,7 @@ export default function DeleteButton() {
       method: "DELETE",
     })
       .then((response) => {
-        if (response.status === 201 || response.status === 200 || response.status === 204) {
+        if (response.status === 204) {
           customMessage = (
             <>
               <Text>Resource successfully deleted!&nbsp;</Text>

--- a/components/DeleteButton.tsx
+++ b/components/DeleteButton.tsx
@@ -1,96 +1,108 @@
 import { useRouter } from "next/router";
 import { Button, Text } from "@mantine/core";
-import { cleanNotifications, showNotification, NotificationProps } from "@mantine/notifications";
+import { cleanNotifications, showNotification, NotificationProps, MantineProvider } from "@mantine/notifications";
 import { Check, X } from "tabler-icons-react";
-import { useModals } from '@mantine/modals';
+import { useModals } from "@mantine/modals";
+import { replaceTeal } from "../styles/codeColorScheme";
 
+/**
+ * DeleteButton is a component for rendering a delete resource button
+ * @returns Button that, when clicked, displays a notification verifying that the user
+ * wants to delete the resource. Only deletes if the user confirms, cancels otherwise.
+ */
+export default function DeleteButton() {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const router = useRouter();
+  const modals = useModals();
+  const { resourceType, id } = router.query;
 
-export default function DeleteButton () {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const router = useRouter();
-    const modals = useModals();
-    const { resourceType, id } = router.query;
+  let customMessage: NotificationProps["message"] = <div>Problem connecting to server</div>;
+  let notifProps: NotificationProps = {
+    message: customMessage,
+    color: "red",
+    icon: <X size={18} />,
+    autoClose: false,
+  };
 
-    let customMessage: NotificationProps["message"] = <div>Problem connecting to server</div>;
-    let notifProps: NotificationProps = {
-      message: customMessage,
-      color: "red",
-      icon: <X size={18} />,
-      autoClose: false,
-    };
-
-   const deleteHandler = () => {
-    
+  const deleteHandler = () => {
+    //delete the resource from the server
     fetch(`${process.env.NEXT_PUBLIC_DEQM_SERVER}/${resourceType}/${id}`, {
-      method: "DELETE"
+      method: "DELETE",
     })
-    .then((response) => {
-    if (response.status === 201 || response.status === 200 || response.status === 204) {
-      customMessage = (
-        <>
-          <Text>Resource successfully deleted!&nbsp;</Text>
-        </>
-      );
-      notifProps = {
-        ...notifProps,
-        color: "green",
-        icon: <Check size={18} />,
-      };
-    
-      router.push({ pathname: `/${resourceType}` });
-    } else {
-      customMessage = `${response.status} ${response.statusText}`;
-      return response.json();
-    }
-   })
-   .then((responseBody) => {
-      if (responseBody) {
-        customMessage = (
-          <>
-            <Text weight={500}>{customMessage}&nbsp;</Text>
-            <Text color="red">{responseBody.issue[0].details.text}</Text>
-          </>
-        );
-      }
-        })
-        .catch((error) => {
-            console.log("hereverybad")
+      .then((response) => {
+        if (response.status === 201 || response.status === 200 || response.status === 204) {
           customMessage = (
             <>
-              <Text weight={500}>Problem connecting to server:&nbsp;</Text>
-              <Text color="red">{error.message}</Text>
+              <Text>Resource successfully deleted!&nbsp;</Text>
             </>
           );
-        })
-        .finally(() => {
-          cleanNotifications();
-          showNotification({ ...notifProps, message: customMessage });
-        });
-   
-   }
-    
-    const openDeleteModal = () =>
-      modals.openConfirmModal({
-        title: 'Delete Resource!!!!!',
-        centered: true,
-        children: (
-          <Text size="sm">
-            Are you sure you want to delete {resourceType} {id}? 
-          </Text>
-        ),
-        labels: { confirm: 'Delete', cancel: "Cancel" },
-        confirmProps: { color: 'red' },
-        onCancel: () => console.log("cancel"),
-        onConfirm: () => deleteHandler()
+          notifProps = {
+            ...notifProps,
+            color: "green",
+            icon: <Check size={18} />,
+          };
+
+          //return to resource page
+          router.push({ pathname: `/${resourceType}` });
+        } else {
+          customMessage = `${response.status} ${response.statusText}`;
+          return response.json();
+        }
+      })
+      .then((responseBody) => {
+        if (responseBody) {
+          customMessage = (
+            <>
+              <Text weight={500}>{customMessage}&nbsp;</Text>
+              <Text color="red">{responseBody.issue[0].details.text}</Text>
+            </>
+          );
+        }
+      })
+      .catch((error) => {
+        customMessage = (
+          <>
+            <Text weight={500}>Problem connecting to server:&nbsp;</Text>
+            <Text color="red">{error.message}</Text>
+          </>
+        );
+      })
+      .finally(() => {
+        cleanNotifications();
+        showNotification({ ...notifProps, message: customMessage });
       });
-      
-    return <Button 
-        onClick={openDeleteModal} 
-        color="cyan"
-        radius="md"
-        size="sm"
-        variant="filled"
-        style={{
-          float: "right",
-        }}>Delete</Button>
-  }
+  };
+
+  // create a modal verifying if the user wants to delete the given resource
+  const openDeleteModal = () =>
+    modals.openConfirmModal({
+      title: "Delete Resource",
+      centered: true,
+      children: (
+        <Text size="sm">
+          Are you sure you want to delete {resourceType} {id}?
+        </Text>
+      ),
+      labels: { confirm: "Delete", cancel: "Cancel" },
+      confirmProps: { color: "red" },
+      onCancel: () => console.log("cancel"),
+      onConfirm: () => deleteHandler(),
+    });
+
+  return (
+    <Button
+      onClick={openDeleteModal}
+      color="pink"
+      radius="md"
+      size="sm"
+      variant="filled"
+      style={{
+        float: "right",
+        marginRight: "16px",
+        marginLeft: "8px",
+      }}
+    >
+      Delete
+    </Button>
+  );
+}

--- a/components/DeleteButton.tsx
+++ b/components/DeleteButton.tsx
@@ -1,9 +1,8 @@
 import { useRouter } from "next/router";
 import { Button, Text } from "@mantine/core";
-import { cleanNotifications, showNotification, NotificationProps, MantineProvider } from "@mantine/notifications";
+import { cleanNotifications, showNotification, NotificationProps } from "@mantine/notifications";
 import { Check, X } from "tabler-icons-react";
 import { useModals } from "@mantine/modals";
-import { replaceTeal } from "../styles/codeColorScheme";
 
 /**
  * DeleteButton is a component for rendering a delete resource button

--- a/components/DeleteButton.tsx
+++ b/components/DeleteButton.tsx
@@ -1,0 +1,96 @@
+import { useRouter } from "next/router";
+import { Button, Text } from "@mantine/core";
+import { cleanNotifications, showNotification, NotificationProps } from "@mantine/notifications";
+import { Check, X } from "tabler-icons-react";
+import { useModals } from '@mantine/modals';
+
+
+export default function DeleteButton () {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const router = useRouter();
+    const modals = useModals();
+    const { resourceType, id } = router.query;
+
+    let customMessage: NotificationProps["message"] = <div>Problem connecting to server</div>;
+    let notifProps: NotificationProps = {
+      message: customMessage,
+      color: "red",
+      icon: <X size={18} />,
+      autoClose: false,
+    };
+
+   const deleteHandler = () => {
+    
+    fetch(`${process.env.NEXT_PUBLIC_DEQM_SERVER}/${resourceType}/${id}`, {
+      method: "DELETE"
+    })
+    .then((response) => {
+    if (response.status === 201 || response.status === 200 || response.status === 204) {
+      customMessage = (
+        <>
+          <Text>Resource successfully deleted!&nbsp;</Text>
+        </>
+      );
+      notifProps = {
+        ...notifProps,
+        color: "green",
+        icon: <Check size={18} />,
+      };
+    
+      router.push({ pathname: `/${resourceType}` });
+    } else {
+      customMessage = `${response.status} ${response.statusText}`;
+      return response.json();
+    }
+   })
+   .then((responseBody) => {
+      if (responseBody) {
+        customMessage = (
+          <>
+            <Text weight={500}>{customMessage}&nbsp;</Text>
+            <Text color="red">{responseBody.issue[0].details.text}</Text>
+          </>
+        );
+      }
+        })
+        .catch((error) => {
+            console.log("hereverybad")
+          customMessage = (
+            <>
+              <Text weight={500}>Problem connecting to server:&nbsp;</Text>
+              <Text color="red">{error.message}</Text>
+            </>
+          );
+        })
+        .finally(() => {
+          cleanNotifications();
+          showNotification({ ...notifProps, message: customMessage });
+        });
+   
+   }
+    
+    const openDeleteModal = () =>
+      modals.openConfirmModal({
+        title: 'Delete Resource!!!!!',
+        centered: true,
+        children: (
+          <Text size="sm">
+            Are you sure you want to delete {resourceType} {id}? 
+          </Text>
+        ),
+        labels: { confirm: 'Delete', cancel: "Cancel" },
+        confirmProps: { color: 'red' },
+        onCancel: () => console.log("cancel"),
+        onConfirm: () => deleteHandler()
+      });
+      
+    return <Button 
+        onClick={openDeleteModal} 
+        color="cyan"
+        radius="md"
+        size="sm"
+        variant="filled"
+        style={{
+          float: "right",
+        }}>Delete</Button>
+  }

--- a/components/DeleteButton.tsx
+++ b/components/DeleteButton.tsx
@@ -84,7 +84,6 @@ export default function DeleteButton() {
       ),
       labels: { confirm: "Delete", cancel: "Cancel" },
       confirmProps: { color: "red" },
-      onCancel: () => console.log("cancel"),
       onConfirm: () => deleteHandler(),
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1102,6 +1102,11 @@
       "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-4.2.9.tgz",
       "integrity": "sha512-oLtlSXkl99vPGBTR9yoVCWoCQ25Bc4WhPci31iERMLMM/0fz85CZayQcAC4etq6un6rDiRNu6jq0YB1S5stmPg=="
     },
+    "@mantine/modals": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@mantine/modals/-/modals-4.2.12.tgz",
+      "integrity": "sha512-UEcz2kZIt5fQELTuV0YKtqNzNVs+lyP8aqoNJAUgl3u4EKg4YS0WTTqCOJ6ACtAdmCc10lemgQ3zV/HnNh15Ng=="
+    },
     "@mantine/next": {
       "version": "4.2.9",
       "resolved": "https://registry.npmjs.org/@mantine/next/-/next-4.2.9.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@fhir-typescript/r4-core": "0.0.12-beta.11",
     "@mantine/core": "^4.2.4",
     "@mantine/hooks": "^4.2.4",
+    "@mantine/modals": "^4.2.12",
     "@mantine/next": "^4.2.4",
     "@mantine/notifications": "^4.2.10",
     "@mantine/prism": "^4.2.11",

--- a/pages/[resourceType]/[id]/index.tsx
+++ b/pages/[resourceType]/[id]/index.tsx
@@ -1,14 +1,20 @@
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { Prism } from "@mantine/prism";
-import { Button, Divider, ScrollArea, Stack, Center, Loader, SimpleGrid } from "@mantine/core";
+import { Button, Divider, ScrollArea, Stack, Center, Loader, SimpleGrid, MantineProvider } from "@mantine/core";
 import BackButton from "../../../components/BackButton";
 import Link from "next/link";
 import { cleanNotifications, showNotification } from "@mantine/notifications";
 import DeleteButton from "../../../components/DeleteButton";
 import { ModalsProvider } from "@mantine/modals";
-
-
+import {
+  replaceDark,
+  replaceGray,
+  replaceTeal,
+  replaceRed,
+  replaceBlue,
+  replaceDelete
+} from "../../../styles/codeColorScheme";
 /**
  * Component which displays the JSON body of an individual resource and a back button.
  * If the resource is a Measure, an evaluate measure button is also displayed.
@@ -51,6 +57,9 @@ function ResourceIDPage() {
   const renderButtons = (
     <div>
       <BackButton />
+      <ModalsProvider>
+      <DeleteButton />
+      </ModalsProvider>
       {resourceType === "Measure" && (
         <Link href={`/${resourceType}/${id}/evaluate`} key={`evaluate-measure-${id}`} passHref>
           <Button
@@ -81,13 +90,11 @@ function ResourceIDPage() {
             marginRight: "8px",
             marginLeft: "8px",
           }}
+          key={`update-${id}`}
         >
           <div> Update </div>
         </Button>
       </Link>
-      <ModalsProvider>
-      <DeleteButton/>
-      </ModalsProvider>
     </div>
   );
 
@@ -108,13 +115,27 @@ function ResourceIDPage() {
         </div>
         <Divider my="sm" />
         <ScrollArea>
-          <Prism
-            language="json"
-            data-testid="prism-page-content"
-            style={{ maxWidth: "77vw", height: "80vh" }}
+<MantineProvider
+            //changes hex values associated with each Mantine color name to improve UI
+            theme={{
+              colors: {
+                gray: replaceGray,
+                dark: replaceDark,
+                teal: replaceTeal,
+                red: replaceRed,
+                blue: replaceBlue,
+              },
+            }}
           >
-            {pageBody}
-          </Prism>
+            <Prism
+              language="json"
+              data-testid="prism-page-content"
+              colorScheme="dark"
+              style={{  maxWidth: "77vw", height: "80vh", backgroundColor: "#FFFFFF" }}
+            > 
+              {pageBody}
+            </Prism>
+          </MantineProvider>
         </ScrollArea>
       </Stack>
     </div>

--- a/pages/[resourceType]/[id]/index.tsx
+++ b/pages/[resourceType]/[id]/index.tsx
@@ -1,16 +1,7 @@
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { Prism } from "@mantine/prism";
-import {
-  Button,
-  Divider,
-  ScrollArea,
-  Stack,
-  Center,
-  Loader,
-  SimpleGrid,
-  MantineProvider,
-} from "@mantine/core";
+import { Button, Divider, ScrollArea, Stack, Center, Loader, MantineProvider } from "@mantine/core";
 import BackButton from "../../../components/BackButton";
 import Link from "next/link";
 import { cleanNotifications, showNotification } from "@mantine/notifications";
@@ -67,16 +58,16 @@ function ResourceIDPage() {
     <div>
       <BackButton />
       <MantineProvider
-          //changes hex values associated with each Mantine color name to improve UI
-          theme={{
-            colors: {
-              pink: replaceDelete,
-            },
-          }}
-        >
-          <ModalsProvider>
-            <DeleteButton />
-          </ModalsProvider>
+        //changes hex values associated with each Mantine color name to improve UI
+        theme={{
+          colors: {
+            pink: replaceDelete,
+          },
+        }}
+      >
+        <ModalsProvider>
+          <DeleteButton />
+        </ModalsProvider>
       </MantineProvider>
       {resourceType === "Measure" && (
         <Link href={`/${resourceType}/${id}/evaluate`} key={`evaluate-measure-${id}`} passHref>
@@ -149,8 +140,8 @@ function ResourceIDPage() {
               language="json"
               data-testid="prism-page-content"
               colorScheme="dark"
-              style={{  maxWidth: "77vw", height: "80vh", backgroundColor: "#FFFFFF" }}
-            > 
+              style={{ maxWidth: "77vw", height: "80vh", backgroundColor: "#FFFFFF" }}
+            >
               {pageBody}
             </Prism>
           </MantineProvider>

--- a/pages/[resourceType]/[id]/index.tsx
+++ b/pages/[resourceType]/[id]/index.tsx
@@ -1,10 +1,13 @@
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { Prism } from "@mantine/prism";
-import { Button, Divider, ScrollArea, Stack, Center, Loader } from "@mantine/core";
+import { Button, Divider, ScrollArea, Stack, Center, Loader, SimpleGrid } from "@mantine/core";
 import BackButton from "../../../components/BackButton";
 import Link from "next/link";
 import { cleanNotifications, showNotification } from "@mantine/notifications";
+import DeleteButton from "../../../components/DeleteButton";
+import { ModalsProvider } from "@mantine/modals";
+
 
 /**
  * Component which displays the JSON body of an individual resource and a back button.
@@ -48,22 +51,6 @@ function ResourceIDPage() {
   const renderButtons = (
     <div>
       <BackButton />
-      <Link href={`/${resourceType}/${id}/update`} key={`update-${id}`} passHref>
-        <Button
-          component="a"
-          color="cyan"
-          radius="md"
-          size="sm"
-          variant="filled"
-          style={{
-            float: "right",
-            marginRight: "8px",
-            marginLeft: "8px",
-          }}
-        >
-          <div> Update </div>
-        </Button>
-      </Link>
       {resourceType === "Measure" && (
         <Link href={`/${resourceType}/${id}/evaluate`} key={`evaluate-measure-${id}`} passHref>
           <Button
@@ -82,6 +69,25 @@ function ResourceIDPage() {
           </Button>
         </Link>
       )}
+      <Link href={`/${resourceType}/${id}/update`} key={`update-${id}`} passHref>
+        <Button
+          component="a"
+          color="cyan"
+          radius="md"
+          size="sm"
+          variant="filled"
+          style={{
+            float: "right",
+            marginRight: "8px",
+            marginLeft: "8px",
+          }}
+        >
+          <div> Update </div>
+        </Button>
+      </Link>
+      <ModalsProvider>
+      <DeleteButton/>
+      </ModalsProvider>
     </div>
   );
 

--- a/pages/[resourceType]/[id]/index.tsx
+++ b/pages/[resourceType]/[id]/index.tsx
@@ -1,7 +1,16 @@
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { Prism } from "@mantine/prism";
-import { Button, Divider, ScrollArea, Stack, Center, Loader, SimpleGrid, MantineProvider } from "@mantine/core";
+import {
+  Button,
+  Divider,
+  ScrollArea,
+  Stack,
+  Center,
+  Loader,
+  SimpleGrid,
+  MantineProvider,
+} from "@mantine/core";
 import BackButton from "../../../components/BackButton";
 import Link from "next/link";
 import { cleanNotifications, showNotification } from "@mantine/notifications";
@@ -13,7 +22,7 @@ import {
   replaceTeal,
   replaceRed,
   replaceBlue,
-  replaceDelete
+  replaceDelete,
 } from "../../../styles/codeColorScheme";
 /**
  * Component which displays the JSON body of an individual resource and a back button.
@@ -57,9 +66,18 @@ function ResourceIDPage() {
   const renderButtons = (
     <div>
       <BackButton />
-      <ModalsProvider>
-      <DeleteButton />
-      </ModalsProvider>
+      <MantineProvider
+          //changes hex values associated with each Mantine color name to improve UI
+          theme={{
+            colors: {
+              pink: replaceDelete,
+            },
+          }}
+        >
+          <ModalsProvider>
+            <DeleteButton />
+          </ModalsProvider>
+      </MantineProvider>
       {resourceType === "Measure" && (
         <Link href={`/${resourceType}/${id}/evaluate`} key={`evaluate-measure-${id}`} passHref>
           <Button
@@ -115,7 +133,7 @@ function ResourceIDPage() {
         </div>
         <Divider my="sm" />
         <ScrollArea>
-<MantineProvider
+          <MantineProvider
             //changes hex values associated with each Mantine color name to improve UI
             theme={{
               colors: {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -18,7 +18,7 @@ import { textGray } from "../styles/appColors";
 
 export default function App(props: AppProps) {
   const { Component, pageProps } = props;
- 
+
   return (
     <>
       <Head>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -15,6 +15,7 @@ import { NotificationsProvider } from "@mantine/notifications";
 import { ResourceCounts } from "../components/ResourceCounts";
 import Link from "next/link";
 import { textGray } from "../styles/appColors";
+// import { ModalsProvider } from '@mantine/modals';
 
 export default function App(props: AppProps) {
   const { Component, pageProps } = props;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -15,11 +15,10 @@ import { NotificationsProvider } from "@mantine/notifications";
 import { ResourceCounts } from "../components/ResourceCounts";
 import Link from "next/link";
 import { textGray } from "../styles/appColors";
-// import { ModalsProvider } from '@mantine/modals';
 
 export default function App(props: AppProps) {
   const { Component, pageProps } = props;
-
+ 
   return (
     <>
       <Head>

--- a/styles/codeColorScheme.tsx
+++ b/styles/codeColorScheme.tsx
@@ -1,0 +1,79 @@
+type stringArray = [string, string, string, string, string, string, string, string, string, string];
+
+export const replaceGray: stringArray = [
+  "#ffffff",
+  "#3b3f3f",
+  "#3b3f3f",
+  "#3b3f3f",
+  "#3b3f3f",
+  "#3b3f3f",
+  "#3b3f3f",
+  "#3b3f3f",
+  "#3b3f3f",
+  "#3b3f3f",
+];
+
+export const replaceDark: stringArray = [
+  "#FFFFFF",
+  "#FFFFFF",
+  "#FFFFFF",
+  "#FFFFFF",
+  "#FFFFFF",
+  "#FFFFFF",
+  "#FFFFFF",
+  "#FFFFFF",
+  "#FFFFFF",
+  "#FFFFFF",
+];
+
+export const replaceTeal: stringArray = [
+  "#eb5262",
+  "#eb5262",
+  "#eb5262",
+  "#eb5262",
+  "#eb5262",
+  "#eb5262",
+  "#eb5262",
+  "#eb5262",
+  "#eb5262",
+  "#eb5262",
+];
+
+export const replaceRed: stringArray = [
+  "#00922A",
+  "#00922A",
+  "#00922A",
+  "#00922A",
+  "#00922A",
+  "#00922A",
+  "#00922A",
+  "#00922A",
+  "#00922A",
+  "#00922A",
+];
+
+export const replaceBlue: stringArray = [
+  "#1F44FF",
+  "#1F44FF",
+  "#1F44FF",
+  "#1F44FF",
+  "#1F44FF",
+  "#1F44FF",
+  "#1F44FF",
+  "#1F44FF",
+  "#1F44FF",
+  "#1F44FF",
+];
+
+export const replaceDelete: stringArray = [
+    "#A61E4D",
+    "#A61E4D",
+    "#A61E4D",
+    "#A61E4D",
+    "#A61E4D",
+    "#CE3D4C",
+    "#EB5262",
+    "#CE3D4C",
+    "#A61E4D",
+    "#A61E4D",
+  ];

--- a/styles/codeColorScheme.tsx
+++ b/styles/codeColorScheme.tsx
@@ -66,14 +66,14 @@ export const replaceBlue: stringArray = [
 ];
 
 export const replaceDelete: stringArray = [
-    "#A61E4D",
-    "#A61E4D",
-    "#A61E4D",
-    "#A61E4D",
-    "#A61E4D",
-    "#CE3D4C",
-    "#EB5262",
-    "#CE3D4C",
-    "#A61E4D",
-    "#A61E4D",
-  ];
+  "#A61E4D",
+  "#A61E4D",
+  "#A61E4D",
+  "#A61E4D",
+  "#A61E4D",
+  "#CE3D4C",
+  "#EB5262",
+  "#CE3D4C",
+  "#A61E4D",
+  "#A61E4D",
+];


### PR DESCRIPTION
## Summary
Implementation of the delete resource button. When clicked, a modal pops up asking the user to confirm if they want to delete the resource or to cancel. Upon deletion, a DELETE request with the resource ID is sent to the server. Upon cancellation, the user returns to the unchanged resource ID page.

## New behavior
In /[resourceType]/[id]/index, there is now a delete button. When clicked, a modal pops up with the option of continuing with the deletion or cancelling. From here, there are three possible outcomes:
- If the resource is deleted successfully, a success notification appears and the user is redirected to the resource’s home page, where the updated body is displayed.  
- If the deletion is unsuccessful (server returns 401, fetch throws an error, etc.), the modal disappears and an error message notification appears on the unchanged resource ID page
- If the deletion is cancelled by the user, the modal disappears and the user returns to the unchanged resource ID page

## Code changes
- **components/deleteButton**  added, implements the delete button and the modal that appears on click
-  **pages/[resourceType]/[id]/index.tsx** now includes delete button
- **__tests__/pages/resource/[id]/index.test.tsx** expects a delete button on the page that, on click, displays a delete modal
- **styles/codeColorScheme.tsx** adds new color arrays to replace Mantine color scheme for improved UI 

## Testing Guidance
- See the README.md for first time setup instructions.
- run the test server on localhost:3000
- To start the frontend: `npm run dev` then navigate to http://localhost:3001 in a browser
- Click on any resource type from the navigation menu on the left. Then click on any of the listed resource IDs. This will load that resource's home page. Then click on the Delete button in the upper right hand corner of the main page body. A modal should appear with the option to cancel or delete. 
Test the update implementation from here in the following 2 ways:

  1. Click the “Delete” button in the modal. User should be directed to the resourceType home page, where the resource’s ID should no longer appear in the list. (Note: Since only 10 resources display, try deleting a resource with fewer than 10 resources to more easily check that the resource disappears. The resource count on the side will not decrease—that functionality relies on a branch that has not yet been merged). 
  2. Click the cancel button. User should be directed back to the resource’s ID page, displaying the  unchanged JSON body of that individual resource

- Run the unit tests: `npm run test`