### PR TITLE
evaluate measure button

### DIFF
--- a/__tests__/pages/resource/id/evaluate.test.tsx
+++ b/__tests__/pages/resource/id/evaluate.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { createMockRouter } from "../../../helpers/testHelpers";
+import { RouterContext } from "next/dist/shared/lib/router-context";
+import EvaluateMeasurePage from "../../../../pages/[resourceType]/[id]/evaluate";
+
+describe("Test evaluate page render for measure", () => {
+  it("should display expected text", async () => {
+    await act(async () => {
+      render(
+        <RouterContext.Provider
+          value={createMockRouter({
+            query: { resourceType: "Measure", id: "Measure-12" },
+          })}
+        >
+          <EvaluateMeasurePage />
+        </RouterContext.Provider>,
+      );
+    });
+
+    expect(screen.getByText(/Coming soon.../)).toBeInTheDocument();
+  });
+});
+
+describe("Test evaluate page render for non-measure", () => {
+  it("should display an error message", async () => {
+    await act(async () => {
+      render(
+        <RouterContext.Provider
+          value={createMockRouter({
+            query: { resourceType: "DiagnosticReport", id: "denom-EXM125-3" },
+          })}
+        >
+          <EvaluateMeasurePage />
+        </RouterContext.Provider>,
+      );
+    });
+
+    expect(
+      screen.getByText(
+        /Cannot evaluate on resourceType: DiagnosticReport, only on resourceType: Measure/,
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/__tests__/pages/resource/id/index.test.tsx
+++ b/__tests__/pages/resource/id/index.test.tsx
@@ -60,3 +60,26 @@ describe("resource ID render", () => {
     ).toBe(true);
   });
 });
+
+describe("measure resource ID render", () => {
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementation("");
+  });
+
+  it("should display an evaluate measure button", async () => {
+    await act(async () => {
+      render(
+        <RouterContext.Provider
+          value={createMockRouter({
+            query: { resourceType: "Measure", id: "Measure12" },
+          })}
+        >
+          <ResourceIDPage />
+        </RouterContext.Provider>,
+      );
+    });
+
+    //for Measure resources, an additional button named "Evaluate Measure" will be in the document
+    expect(screen.getByRole("link", { name: "Evaluate Measure" })).toBeInTheDocument();
+  });
+});

--- a/__tests__/pages/resource/id/index.test.tsx
+++ b/__tests__/pages/resource/id/index.test.tsx
@@ -38,6 +38,7 @@ describe("resource ID render", () => {
     //check for the expected buttons on the page
     expect(await screen.findByTestId("back-button")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Update" })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Evaluate Measure" })).toBeNull();
 
     //parses out relevant information from the Prism HTML block and stores it in an array
     const spanText = [""];

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -1,0 +1,24 @@
+import { Center } from "@mantine/core";
+import { useRouter } from "next/router";
+
+/**
+ * Page for evaluate measure functionality.
+ * @returns JSX Element
+ */
+const EvaluateMeasurePage = () => {
+  const router = useRouter();
+  const { resourceType } = router.query;
+  if (resourceType === "Measure") {
+    return <div>Coming soon...</div>;
+  } else {
+    return (
+      <Center>
+        <div>
+          Cannot evaluate on resourceType: {`${resourceType}`}, only on resourceType: Measure
+        </div>
+      </Center>
+    );
+  }
+};
+
+export default EvaluateMeasurePage;

--- a/pages/[resourceType]/[id]/index.tsx
+++ b/pages/[resourceType]/[id]/index.tsx
@@ -17,7 +17,6 @@ function ResourceIDPage() {
   const [fetchingError, setFetchingError] = useState(false);
   const [loadingRequest, setLoadingRequest] = useState(false);
   const [pageBody, setPageBody] = useState("");
-  const [evaluateMeasureButton, setEvaluateMeasureButton] = useState(<></>);
 
   useEffect(() => {
     if (resourceType && id) {
@@ -29,32 +28,6 @@ function ResourceIDPage() {
         })
         .then((resourcePageBody) => {
           setPageBody(JSON.stringify(resourcePageBody, null, 2));
-          console.log("resourceType: ", resourceType);
-          //if resource is a measure, an evaluate measure button will be rendered
-          if (resourceType === "Measure") {
-            setEvaluateMeasureButton(
-              <Link
-                href={`/${resourceType}/${id}/evaluate`}
-                key={`evaluate-measure-${id}`}
-                passHref
-              >
-                <Button
-                  component="a"
-                  color="cyan"
-                  radius="md"
-                  size="sm"
-                  variant="filled"
-                  style={{
-                    float: "right",
-                    marginRight: "8px",
-                    marginLeft: "8px",
-                  }}
-                >
-                  <div>Evaluate Measure</div>
-                </Button>
-              </Link>,
-            );
-          }
           setFetchingError(false);
           setLoadingRequest(false);
         })
@@ -91,7 +64,24 @@ function ResourceIDPage() {
           <div> Update </div>
         </Button>
       </Link>
-      {evaluateMeasureButton}
+      {resourceType === "Measure" && (
+        <Link href={`/${resourceType}/${id}/evaluate`} key={`evaluate-measure-${id}`} passHref>
+          <Button
+            component="a"
+            color="cyan"
+            radius="md"
+            size="sm"
+            variant="filled"
+            style={{
+              float: "right",
+              marginRight: "8px",
+              marginLeft: "8px",
+            }}
+          >
+            <div>Evaluate Measure</div>
+          </Button>
+        </Link>
+      )}
     </div>
   );
 

--- a/pages/[resourceType]/[id]/index.tsx
+++ b/pages/[resourceType]/[id]/index.tsx
@@ -7,7 +7,8 @@ import Link from "next/link";
 import { cleanNotifications, showNotification } from "@mantine/notifications";
 
 /**
- * Component which displays the JSON body of an individual resource and a back button
+ * Component which displays the JSON body of an individual resource and a back button.
+ * If the resource is a Measure, an evaluate measure button is also displayed.
  * @returns JSON content of the individual resource in a Prism component, and a back button
  */
 function ResourceIDPage() {
@@ -16,6 +17,7 @@ function ResourceIDPage() {
   const [fetchingError, setFetchingError] = useState(false);
   const [loadingRequest, setLoadingRequest] = useState(false);
   const [pageBody, setPageBody] = useState("");
+  const [evaluateMeasureButton, setEvaluateMeasureButton] = useState(<></>);
 
   useEffect(() => {
     if (resourceType && id) {
@@ -27,6 +29,32 @@ function ResourceIDPage() {
         })
         .then((resourcePageBody) => {
           setPageBody(JSON.stringify(resourcePageBody, null, 2));
+          console.log("resourceType: ", resourceType);
+          //if resource is a measure, an evaluate measure button will be rendered
+          if (resourceType === "Measure") {
+            setEvaluateMeasureButton(
+              <Link
+                href={`/${resourceType}/${id}/evaluate`}
+                key={`evaluate-measure-${id}`}
+                passHref
+              >
+                <Button
+                  component="a"
+                  color="cyan"
+                  radius="md"
+                  size="sm"
+                  variant="filled"
+                  style={{
+                    float: "right",
+                    marginRight: "8px",
+                    marginLeft: "8px",
+                  }}
+                >
+                  <div>Evaluate Measure</div>
+                </Button>
+              </Link>,
+            );
+          }
           setFetchingError(false);
           setLoadingRequest(false);
         })
@@ -47,14 +75,7 @@ function ResourceIDPage() {
   const renderButtons = (
     <div>
       <BackButton />
-      <Link
-        href={{
-          pathname: "/[resourceType]/[id]/update",
-          query: { resourceType: resourceType, id: id },
-        }}
-        key={`update-${id}`}
-        passHref
-      >
+      <Link href={`/${resourceType}/${id}/update`} key={`update-${id}`} passHref>
         <Button
           component="a"
           color="cyan"
@@ -63,11 +84,14 @@ function ResourceIDPage() {
           variant="filled"
           style={{
             float: "right",
+            marginRight: "8px",
+            marginLeft: "8px",
           }}
         >
           <div> Update </div>
         </Button>
       </Link>
+      {evaluateMeasureButton}
     </div>
   );
 
@@ -88,7 +112,11 @@ function ResourceIDPage() {
         </div>
         <Divider my="sm" />
         <ScrollArea>
-          <Prism language="json" data-testid="prism-page-content" style={{ height: "80vh" }}>
+          <Prism
+            language="json"
+            data-testid="prism-page-content"
+            style={{ maxWidth: "77vw", height: "80vh" }}
+          >
             {pageBody}
           </Prism>
         </ScrollArea>


### PR DESCRIPTION
## Summary
Implementation of an “Evaluate Measure” button. 
## New behavior
An “Evaluate Measure” button is rendered on the home page of any Measure resource. When clicked, user is redirected to Measure/[id]/evaluate. For now, there is only “Coming soon…” text rendered on this page.
If a user attempts to navigate to [resourceType]/[id]/evaluate for a non-Measure resourceType, an error message appears on the screen.
## Code changes
- **pages/[resource]/[id]/evaluate.tsx**  added, renders the evaluate page 
-  **pages/[resource]/[id]/index.tsx** now includes an “Evaluate Measure” button for Measure resources
- **__tests__/pages/resource/id/evaluate.test.tsx**, **__tests__/pages/resource/id/index.test.tsx** unit tests added

## Testing Guidance
- See the README.md for first time setup instructions.
#### Test in a browser
- To start the frontend: `npm run dev` then navigate to http://localhost:3001 in a browser
1. Valid navigation:
    - Click on “Measure” from the left-hand-side navigation menu. This will load the measure resource ID page. Click on any of the IDs. 
    - There should be an “Evaluate Measure” button at the top of the main page body, to the left of the “Update” button. Click this button. User should be redirected to /Measure/[id]/evaluate page, where there is the text “Coming soon…” displayed.
2. Invalid navigation (non-Measure resource): 
    - Navigate to any [resourceType]/[id] page for a non-Measure resource. Then add "evaluate" to the end of the url and hit enter. An error message should be displayed on the main page body:  "Cannot evaluate on resourceType: [resourceType], only on resourceType: Measure"
#### Unit tests
- Run the unit tests: `npm run test`
