### PR TITLE
Select autocomplete

### DIFF
--- a/__tests__/components/SelectComponent.test.tsx
+++ b/__tests__/components/SelectComponent.test.tsx
@@ -53,6 +53,29 @@ const NO_RESOURCE_ID: fhirJson.Bundle = {
   entry: [],
 };
 
+describe("Select component no practitioners", () => {
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementation(NO_RESOURCE_ID);
+  });
+
+  window.ResizeObserver = mockResizeObserver;
+
+  it("should display no practioners", async () => {
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <SelectComponent
+            resourceType="Practitioner"
+            practitionerValue=""
+            setPractitionerValue={jest.fn()}
+          />,
+        ),
+      );
+    });
+  });
+  expect(screen.findByText("No resources of type Practitioner found")).toBeInTheDocument;
+});
+
 describe("Select component render", () => {
   beforeAll(() => {
     global.fetch = getMockFetchImplementation(RESOURCE_ID_BODY);
@@ -62,7 +85,15 @@ describe("Select component render", () => {
 
   it("should display a dropdown menu populated with resource ID's when prompted by user key presses", async () => {
     await act(async () => {
-      render(mantineRecoilWrap(<SelectComponent resourceType="Practitioner" />));
+      render(
+        mantineRecoilWrap(
+          <SelectComponent
+            resourceType="Practitioner"
+            practitionerValue=""
+            setPractitionerValue={jest.fn()}
+          />,
+        ),
+      );
     });
 
     //retrieves the combobox and the input field within the combobox
@@ -77,29 +108,9 @@ describe("Select component render", () => {
       fireEvent.keyDown(autocomplete, { key: "Enter" });
     });
 
-    //verifies that the input field updates appropriately
-    expect(input.getAttribute("value")).toBe("P");
-
     //verifies that the drop down autocomplete menu is populated with the resource IDs fetched from the server
     const options = screen.getAllByRole("option");
     expect(options[0].textContent).toBe("Practitioner/denom-EXM125-3");
     expect(options[1].textContent).toBe("Practitioner/numer-EXM125-3");
-    screen.debug();
-  });
-});
-
-describe("Select component no practitioners", () => {
-  beforeAll(() => {
-    global.fetch = getMockFetchImplementation(NO_RESOURCE_ID);
-  });
-
-  window.ResizeObserver = mockResizeObserver;
-
-  it("should display no practioners", async () => {
-    await act(async () => {
-      render(mantineRecoilWrap(<SelectComponent resourceType="Practitioner" />));
-    });
-
-    expect(screen.getByText("No resources of type Practitioner found")).toBeInTheDocument;
   });
 });

--- a/__tests__/components/SelectComponent.test.tsx
+++ b/__tests__/components/SelectComponent.test.tsx
@@ -44,6 +44,16 @@ const RESOURCE_ID_BODY: fhirJson.Bundle = {
   ],
 };
 
+const NO_RESOURCE_ID: fhirJson.Bundle = {
+  resourceType: "Bundle",
+  meta: {
+    lastUpdated: "2022-06-23T19:52:58.721Z",
+  },
+  type: "searchset",
+  total: 0,
+  entry: [],
+};
+
 describe("Select component render", () => {
   beforeAll(() => {
     global.fetch = getMockFetchImplementation(RESOURCE_ID_BODY);
@@ -77,5 +87,22 @@ describe("Select component render", () => {
     expect(options[0].textContent).toBe("Practitioner/denom-EXM125-3");
     expect(options[1].textContent).toBe("Practitioner/numer-EXM125-3");
     screen.debug();
+  });
+});
+
+describe("Select component no practitioners", () => {
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementation(NO_RESOURCE_ID);
+  });
+
+  window.ResizeObserver = mockResizeObserver;
+  const user = userEvent.setup();
+
+  it("should display no practioners", async () => {
+    await act(async () => {
+      render(mantineRecoilWrap(<SelectComponent resourceType="Practitioner" />));
+    });
+
+    expect(screen.getByText("No resources of type Practitioner found")).toBeInTheDocument;
   });
 });

--- a/__tests__/components/SelectComponent.test.tsx
+++ b/__tests__/components/SelectComponent.test.tsx
@@ -64,11 +64,7 @@ describe("Select component no practitioners", () => {
     await act(async () => {
       render(
         mantineRecoilWrap(
-          <SelectComponent
-            resourceType="Practitioner"
-            practitionerValue=""
-            setPractitionerValue={jest.fn()}
-          />,
+          <SelectComponent resourceType="Practitioner" value="" setValue={jest.fn()} />,
         ),
       );
     });
@@ -87,11 +83,7 @@ describe("Select component render", () => {
     await act(async () => {
       render(
         mantineRecoilWrap(
-          <SelectComponent
-            resourceType="Practitioner"
-            practitionerValue=""
-            setPractitionerValue={jest.fn()}
-          />,
+          <SelectComponent resourceType="Practitioner" value="" setValue={jest.fn()} />,
         ),
       );
     });

--- a/__tests__/components/SelectComponent.test.tsx
+++ b/__tests__/components/SelectComponent.test.tsx
@@ -7,7 +7,6 @@ import {
 } from "../helpers/testHelpers";
 import { fhirJson } from "@fhir-typescript/r4-core";
 import SelectComponent from "../../components/SelectComponent";
-import userEvent from "@testing-library/user-event";
 
 const RESOURCE_ID_BODY: fhirJson.Bundle = {
   resourceType: "Bundle",
@@ -60,7 +59,6 @@ describe("Select component render", () => {
   });
 
   window.ResizeObserver = mockResizeObserver;
-  const user = userEvent.setup();
 
   it("should display a dropdown menu populated with resource ID's when prompted by user key presses", async () => {
     await act(async () => {
@@ -96,7 +94,6 @@ describe("Select component no practitioners", () => {
   });
 
   window.ResizeObserver = mockResizeObserver;
-  const user = userEvent.setup();
 
   it("should display no practioners", async () => {
     await act(async () => {

--- a/__tests__/components/SelectComponent.test.tsx
+++ b/__tests__/components/SelectComponent.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, act, within, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import {
+  mantineRecoilWrap,
+  getMockFetchImplementation,
+  mockResizeObserver,
+} from "../helpers/testHelpers";
+import { fhirJson } from "@fhir-typescript/r4-core";
+import SelectComponent from "../../components/SelectComponent";
+import userEvent from "@testing-library/user-event";
+
+const RESOURCE_ID_BODY: fhirJson.Bundle = {
+  resourceType: "Bundle",
+  meta: {
+    lastUpdated: "2022-06-23T19:52:58.721Z",
+  },
+  type: "searchset",
+  total: 2,
+  entry: [
+    {
+      fullUrl: "http://localhost:3000/4_0_1/DiagnosticReport/denom-EXM125-3",
+      resource: {
+        resourceType: "Practitioner",
+        id: "denom-EXM125-3",
+        meta: {
+          profile: [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note",
+          ],
+        },
+      },
+    },
+    {
+      fullUrl: "http://localhost:3000/4_0_1/DiagnosticReport/numer-EXM125-3",
+      resource: {
+        resourceType: "Practitioner",
+        id: "numer-EXM125-3",
+        meta: {
+          profile: [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note",
+          ],
+        },
+      },
+    },
+  ],
+};
+
+describe("Select component render", () => {
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementation(RESOURCE_ID_BODY);
+  });
+
+  window.ResizeObserver = mockResizeObserver;
+  const user = userEvent.setup();
+
+  it("should display a dropdown menu populated with resource ID's when prompted by user key presses", async () => {
+    await act(async () => {
+      render(mantineRecoilWrap(<SelectComponent resourceType="Practitioner" />));
+    });
+
+    //retrieves the combobox and the input field within the combobox
+    const autocomplete = screen.getByRole("combobox");
+    const input = within(autocomplete).getByRole("searchbox");
+    autocomplete.focus();
+
+    //mocks user key clicks to test the input fields and drop down menus
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "P" } });
+      fireEvent.keyDown(autocomplete, { key: "ArrowDown" });
+      fireEvent.keyDown(autocomplete, { key: "Enter" });
+    });
+
+    //verifies that the input field updates appropriately
+    expect(input.getAttribute("value")).toBe("P");
+
+    //verifies that the drop down autocomplete menu is populated with the resource IDs fetched from the server
+    const options = screen.getAllByRole("option");
+    expect(options[0].textContent).toBe("Practitioner/denom-EXM125-3");
+    expect(options[1].textContent).toBe("Practitioner/numer-EXM125-3");
+    screen.debug();
+  });
+});

--- a/__tests__/pages/resource/id/evaluate.test.tsx
+++ b/__tests__/pages/resource/id/evaluate.test.tsx
@@ -9,6 +9,8 @@ import {
 import { RouterContext } from "next/dist/shared/lib/router-context";
 import EvaluateMeasurePage from "../../../../pages/[resourceType]/[id]/evaluate";
 import { DateTime } from "luxon";
+import { fhirJson } from "@fhir-typescript/r4-core";
+
 
 const MEASURE_BODY_WITH_DATES = {
   resourceType: "Measure",
@@ -40,6 +42,42 @@ const MEASURE_BODY_NO_EFFECTIVE_PERIOD = {
 };
 
 const ERROR_400_RESPONSE_BODY = { issue: [{ details: { text: "Invalid resource ID" } }] };
+
+
+const RESOURCE_ID_BODY: fhirJson.Bundle = {
+  resourceType: "Bundle",
+  meta: {
+    lastUpdated: "2022-06-23T19:52:58.721Z",
+  },
+  type: "searchset",
+  total: 2,
+  entry: [
+    {
+      fullUrl: "http://localhost:3000/4_0_1/DiagnosticReport/denom-EXM125-3",
+      resource: {
+        resourceType: "Practitioner",
+        id: "denom-EXM125-3",
+        meta: {
+          profile: [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note",
+          ],
+        },
+      },
+    },
+    {
+      fullUrl: "http://localhost:3000/4_0_1/DiagnosticReport/numer-EXM125-3",
+      resource: {
+        resourceType: "Practitioner",
+        id: "numer-EXM125-3",
+        meta: {
+          profile: [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note",
+          ],
+        },
+      },
+    },
+  ],
+};
 
 describe("Test evaluate page render for measure", () => {
   beforeAll(() => {
@@ -108,12 +146,11 @@ describe("Test evaluate page render for measure", () => {
   });
 });
 
-describe("Test evaluate page render for measure without dates in effective period", () => {
+describe("Test evaluate page render for measure", () => {
   beforeAll(() => {
-    global.fetch = getMockFetchImplementation(MEASURE_BODY_NO_DATES);
+    global.fetch = getMockFetchImplementation(RESOURCE_ID_BODY);
   });
-
-  it("should display DatePickers with default dates", async () => {
+  it("should display expected text", async () => {
     await act(async () => {
       render(
         <RouterContext.Provider
@@ -149,11 +186,15 @@ describe("Test evaluate page render for measure without effective period", () =>
     });
     expect(await screen.findByDisplayValue("January 1, 2022")).toBeInTheDocument();
     expect(screen.getByDisplayValue("December 31, 2022")).toBeInTheDocument();
+    expect(screen.getByText("Select Practitioner")).toBeInTheDocument();
   });
 });
 
 describe("Test evaluate page render for non-measure", () => {
-  it("should display an error message and back button", async () => {
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementation(RESOURCE_ID_BODY);
+  });
+  it("should display an error message", async () => {
     await act(async () => {
       render(
         <RouterContext.Provider

--- a/__tests__/pages/resource/id/evaluate.test.tsx
+++ b/__tests__/pages/resource/id/evaluate.test.tsx
@@ -53,25 +53,25 @@ const RESOURCE_ID_BODY: fhirJson.Bundle = {
   total: 2,
   entry: [
     {
-      fullUrl: "http://localhost:3000/4_0_1/DiagnosticReport/denom-EXM125-3",
+      fullUrl: "http://localhost:3000/4_0_1/PractitionerReport/denom-EXM125-3",
       resource: {
         resourceType: "Practitioner",
         id: "denom-EXM125-3",
         meta: {
           profile: [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerreport-note",
           ],
         },
       },
     },
     {
-      fullUrl: "http://localhost:3000/4_0_1/DiagnosticReport/numer-EXM125-3",
+      fullUrl: "http://localhost:3000/4_0_1/PractitionerReport/numer-EXM125-3",
       resource: {
         resourceType: "Practitioner",
         id: "numer-EXM125-3",
         meta: {
           profile: [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerreport-note",
           ],
         },
       },

--- a/components/SelectComponent.tsx
+++ b/components/SelectComponent.tsx
@@ -1,12 +1,16 @@
 import { fhirJson } from "@fhir-typescript/r4-core";
-import { useState, useEffect } from "react";
+import { useState, useEffect, Dispatch, SetStateAction } from "react";
 import { Autocomplete } from "@mantine/core";
 
 /**
  * @param props include the string resourceType
  * @returns a component with a loading component, server error, or autocomplete select component populated with resource IDs
  */
-export default function SelectComponent(props: { resourceType: string }) {
+export default function SelectComponent(props: {
+  resourceType: string;
+  setPractitionerValue: Dispatch<SetStateAction<string>>;
+  practitionerValue: string;
+}) {
   const resourceType = props.resourceType;
   const [pageBody, setPageBody] = useState<fhirJson.Bundle>();
   const [fetchingError, setFetchingError] = useState(false);
@@ -34,7 +38,12 @@ export default function SelectComponent(props: { resourceType: string }) {
   return loadingRequest ? (
     <div>Loading content...</div>
   ) : !fetchingError && pageBody ? (
-    <PopulateIDHelper jsonBody={pageBody} resourceType={resourceType}></PopulateIDHelper>
+    <PopulateIDHelper
+      jsonBody={pageBody}
+      resourceType={resourceType}
+      setPractitionerValue={props.setPractitionerValue}
+      practitionerValue={props.practitionerValue}
+    ></PopulateIDHelper>
   ) : (
     <div>Problem connecting to server</div>
   );
@@ -44,10 +53,20 @@ export default function SelectComponent(props: { resourceType: string }) {
  * @param props include a fhirJson.Bundle jsonBody, and a string resourceType
  * @returns a component with an error message that resources don't exist or autocomplete select component populated with resource IDs
  */
-function PopulateIDHelper(props: { jsonBody: fhirJson.Bundle; resourceType: string }) {
+function PopulateIDHelper(props: {
+  jsonBody: fhirJson.Bundle;
+  resourceType: string;
+  setPractitionerValue: Dispatch<SetStateAction<string>>;
+  practitionerValue: string;
+}) {
   const entryArray = props.jsonBody.entry;
   if (props.jsonBody.total && props.jsonBody.total > 0 && entryArray != undefined) {
-    return PopulateSelect(entryArray, props.resourceType);
+    return PopulateSelect(
+      entryArray,
+      props.resourceType,
+      props.setPractitionerValue,
+      props.practitionerValue,
+    );
   } else {
     return <div> {`No resources of type ${props.resourceType} found`} </div>;
   }
@@ -57,16 +76,20 @@ function PopulateIDHelper(props: { jsonBody: fhirJson.Bundle; resourceType: stri
  * @param fhirJson.BundleEntry
  * @returns an autocomplete select component populated with resource IDs
  */
-const PopulateSelect = (entry: (fhirJson.BundleEntry | null)[], resourceType: string) => {
+const PopulateSelect = (
+  entry: (fhirJson.BundleEntry | null)[],
+  resourceType: string,
+  setPractitionerValue: Dispatch<SetStateAction<string>>,
+  practitionerValue: string,
+) => {
   const myArray = entry.map((el) => {
     return el?.resource ? `${el.resource.resourceType}/${el.resource.id}` : "";
   });
-  const [value, setValue] = useState("");
 
   return (
     <Autocomplete
-      value={value}
-      onChange={setValue}
+      value={practitionerValue}
+      onChange={setPractitionerValue}
       label={`Select ${resourceType}`}
       placeholder="Start typing to see options"
       data={myArray}

--- a/components/SelectComponent.tsx
+++ b/components/SelectComponent.tsx
@@ -12,17 +12,14 @@ export interface SelectComponentProps {
   resourceType: string;
   setValue: Dispatch<SetStateAction<string>>;
   value: string;
+  jsonBody?: fhirJson.Bundle;
 }
 
 /**
  * @param props include the type interface SelectComponentProps
  * @returns a component with a loading component, server error, or autocomplete select component populated with resource IDs
  */
-export default function SelectComponent(props: SelectComponentProps) {
-  const resourceType = props.resourceType;
-  const setValue = props.setValue;
-  const value = props.value;
-
+export default function SelectComponent({ resourceType, setValue, value }: SelectComponentProps) {
   const [responseBody, setResponseBody] = useState<fhirJson.Bundle>();
   const [fetchingError, setFetchingError] = useState(false);
   const [loadingRequest, setLoadingRequest] = useState(false);
@@ -49,31 +46,58 @@ export default function SelectComponent(props: SelectComponentProps) {
   return loadingRequest ? (
     <div>Loading content...</div>
   ) : !fetchingError && responseBody ? (
-    <PopulateIDHelper jsonBody={responseBody} />
+    <PopulateIDHelper
+      jsonBody={responseBody}
+      resourceType={resourceType}
+      setValue={setValue}
+      value={value}
+    />
   ) : (
     <div>Problem connecting to server</div>
   );
+  // function PopulateIDHelper(props: { jsonBody: fhirJson.Bundle }) {
+  //   const entryArray = props.jsonBody.entry;
 
-  function PopulateIDHelper(props: { jsonBody: fhirJson.Bundle }) {
-    const entryArray = props.jsonBody.entry;
+  //   //makes sure there are resources to display in the dropdown
+  //   if (props.jsonBody.total && props.jsonBody.total > 0 && entryArray != undefined) {
+  //     const myArray = entryArray.map((el) => {
+  //       return el?.resource ? `${el.resource.resourceType}/${el.resource.id}` : "";
+  //     });
+  //     return (
+  //       <Autocomplete
+  //         value={value}
+  //         onChange={setValue}
+  //         label={`Select ${resourceType}`}
+  //         placeholder="Start typing to see options"
+  //         data={myArray}
+  //         limit={10}
+  //       />
+  //     );
+  //   } else {
+  //     return <div> {`No resources of type ${resourceType} found`} </div>;
+  //   }
+  // }
+}
 
-    //makes sure there are resources to display in the dropdown
-    if (props.jsonBody.total && props.jsonBody.total > 0 && entryArray != undefined) {
-      const myArray = entryArray.map((el) => {
-        return el?.resource ? `${el.resource.resourceType}/${el.resource.id}` : "";
-      });
-      return (
-        <Autocomplete
-          value={value}
-          onChange={setValue}
-          label={`Select ${resourceType}`}
-          placeholder="Start typing to see options"
-          data={myArray}
-          limit={10}
-        />
-      );
-    } else {
-      return <div> {`No resources of type ${resourceType} found`} </div>;
-    }
+function PopulateIDHelper({ resourceType, setValue, value, jsonBody }: SelectComponentProps) {
+  const entryArray = jsonBody?.entry;
+
+  //makes sure there are resources to display in the dropdown
+  if (jsonBody?.total && jsonBody?.total > 0 && entryArray != undefined) {
+    const myArray = entryArray.map((el) => {
+      return el?.resource ? `${el.resource.resourceType}/${el.resource.id}` : "";
+    });
+    return (
+      <Autocomplete
+        value={value}
+        onChange={setValue}
+        label={`Select ${resourceType}`}
+        placeholder="Start typing to see options"
+        data={myArray}
+        limit={10}
+      />
+    );
+  } else {
+    return <div> {`No resources of type ${resourceType} found`} </div>;
   }
 }

--- a/components/SelectComponent.tsx
+++ b/components/SelectComponent.tsx
@@ -55,28 +55,6 @@ export default function SelectComponent({ resourceType, setValue, value }: Selec
   ) : (
     <div>Problem connecting to server</div>
   );
-  // function PopulateIDHelper(props: { jsonBody: fhirJson.Bundle }) {
-  //   const entryArray = props.jsonBody.entry;
-
-  //   //makes sure there are resources to display in the dropdown
-  //   if (props.jsonBody.total && props.jsonBody.total > 0 && entryArray != undefined) {
-  //     const myArray = entryArray.map((el) => {
-  //       return el?.resource ? `${el.resource.resourceType}/${el.resource.id}` : "";
-  //     });
-  //     return (
-  //       <Autocomplete
-  //         value={value}
-  //         onChange={setValue}
-  //         label={`Select ${resourceType}`}
-  //         placeholder="Start typing to see options"
-  //         data={myArray}
-  //         limit={10}
-  //       />
-  //     );
-  //   } else {
-  //     return <div> {`No resources of type ${resourceType} found`} </div>;
-  //   }
-  // }
 }
 
 function PopulateIDHelper({ resourceType, setValue, value, jsonBody }: SelectComponentProps) {

--- a/components/SelectComponent.tsx
+++ b/components/SelectComponent.tsx
@@ -6,7 +6,7 @@ import { Autocomplete } from "@mantine/core";
  * @param props include the string resourceType
  * @returns a component with a loading component, server error, or autocomplete select component populated with resource IDs
  */
-export default function SelectComponent(props) {
+export default function SelectComponent(props: { resourceType: string }) {
   const resourceType = props.resourceType;
   const [pageBody, setPageBody] = useState<fhirJson.Bundle>();
   const [fetchingError, setFetchingError] = useState(false);

--- a/components/SelectComponent.tsx
+++ b/components/SelectComponent.tsx
@@ -42,7 +42,7 @@ export default function SelectComponent(props) {
 }
 
 /**
- * @param props.jsonBody: fhirJson.Bundle
+ * @param props include a fhirJson.Bundle jsonBody, and a string resourceType
  * @returns a component with an error message that resources don't exist or autocomplete select component populated with resource IDs
  */
 function PopulateIDHelper(props: { jsonBody: fhirJson.Bundle; resourceType: string }) {
@@ -51,7 +51,7 @@ function PopulateIDHelper(props: { jsonBody: fhirJson.Bundle; resourceType: stri
   if (props.jsonBody.total && props.jsonBody.total > 0 && entryArray != undefined) {
     return PopulateSelect(entryArray, props.resourceType);
   } else {
-    return <div> No resources found </div>;
+    return <div> {`No resources of type ${props.resourceType} found`} </div>;
   }
 }
 

--- a/components/SelectComponent.tsx
+++ b/components/SelectComponent.tsx
@@ -23,18 +23,19 @@ export default function SelectComponent(props: SelectComponentProps) {
   const setValue = props.setValue;
   const value = props.value;
 
-  const [pageBody, setPageBody] = useState<fhirJson.Bundle>();
+  const [responseBody, setResponseBody] = useState<fhirJson.Bundle>();
   const [fetchingError, setFetchingError] = useState(false);
   const [loadingRequest, setLoadingRequest] = useState(false);
 
   useEffect(() => {
     if (resourceType) {
+      setLoadingRequest(true);
       fetch(`${process.env.NEXT_PUBLIC_DEQM_SERVER}/${resourceType}`)
         .then((data) => {
           return data.json() as Promise<fhirJson.Bundle>;
         })
-        .then((resourcePageBody) => {
-          setPageBody(resourcePageBody);
+        .then((resourceResponseBody) => {
+          setResponseBody(resourceResponseBody);
           setFetchingError(false);
           setLoadingRequest(false);
         })
@@ -47,8 +48,8 @@ export default function SelectComponent(props: SelectComponentProps) {
 
   return loadingRequest ? (
     <div>Loading content...</div>
-  ) : !fetchingError && pageBody ? (
-    <PopulateIDHelper jsonBody={pageBody} />
+  ) : !fetchingError && responseBody ? (
+    <PopulateIDHelper jsonBody={responseBody} />
   ) : (
     <div>Problem connecting to server</div>
   );

--- a/components/SelectComponent.tsx
+++ b/components/SelectComponent.tsx
@@ -1,0 +1,78 @@
+import { fhirJson } from "@fhir-typescript/r4-core";
+import { useState, useEffect } from "react";
+import { Autocomplete } from "@mantine/core";
+
+/**
+ * @param props.resourceType
+ * @returns a component with a loading component, server error, or autocomplete select component populated with resource IDs
+ */
+export default function SelectComponent(props) {
+  const resourceType = props.resourceType;
+  const [pageBody, setPageBody] = useState<fhirJson.Bundle>();
+  const [fetchingError, setFetchingError] = useState(false);
+  const [loadingRequest, setLoadingRequest] = useState(false);
+
+  useEffect(() => {
+    if (resourceType) {
+      //setLoadingRequest(true);
+      fetch(`${process.env.NEXT_PUBLIC_DEQM_SERVER}/${resourceType}`)
+        .then((data) => {
+          return data.json() as Promise<fhirJson.Bundle>;
+        })
+        .then((resourcePageBody) => {
+          setPageBody(resourcePageBody);
+          setFetchingError(false);
+          setLoadingRequest(false);
+        })
+        .catch((error) => {
+          console.log(error.message);
+          setFetchingError(true);
+          setLoadingRequest(false);
+        });
+    }
+  }, [resourceType]);
+
+  return loadingRequest ? (
+    <div>Loading content...</div>
+  ) : !fetchingError && pageBody ? (
+    <PopulateIDHelper jsonBody={pageBody}></PopulateIDHelper>
+  ) : (
+    <div>Problem connecting to server</div>
+  );
+}
+
+/**
+ * @param props.jsonBody: fhirJson.Bundle
+ * @returns a component with an error message that resources don't exist or autocomplete select component populated with resource IDs
+ */
+function PopulateIDHelper(props: { jsonBody: fhirJson.Bundle }) {
+  const entryArray = props.jsonBody.entry;
+  console.log(entryArray);
+  if (props.jsonBody.total && props.jsonBody.total > 0 && entryArray != undefined) {
+    return PopulateSelect(entryArray);
+  } else {
+    return <div> No resources found </div>;
+  }
+}
+
+/**
+ * @param fhirJson.BundleEntry
+ * @returns an autocomplete select component populated with resource IDs
+ */
+const PopulateSelect = (entry: (fhirJson.BundleEntry | null)[]) => {
+  const myArray = entry.map((el) => {
+    return el?.resource ? `${el.resource.resourceType}/${el.resource.id}` : "";
+  });
+  const [value, setValue] = useState("");
+
+  return (
+    <Autocomplete
+      value={value}
+      onChange={setValue}
+      label="Select Practitioner"
+      placeholder="Start typing to see options"
+      data={myArray}
+      limit={10}
+    />
+  );
+};

--- a/components/SelectComponent.tsx
+++ b/components/SelectComponent.tsx
@@ -14,7 +14,6 @@ export default function SelectComponent(props: { resourceType: string }) {
 
   useEffect(() => {
     if (resourceType) {
-      //setLoadingRequest(true);
       fetch(`${process.env.NEXT_PUBLIC_DEQM_SERVER}/${resourceType}`)
         .then((data) => {
           return data.json() as Promise<fhirJson.Bundle>;
@@ -47,7 +46,6 @@ export default function SelectComponent(props: { resourceType: string }) {
  */
 function PopulateIDHelper(props: { jsonBody: fhirJson.Bundle; resourceType: string }) {
   const entryArray = props.jsonBody.entry;
-  console.log(entryArray);
   if (props.jsonBody.total && props.jsonBody.total > 0 && entryArray != undefined) {
     return PopulateSelect(entryArray, props.resourceType);
   } else {

--- a/components/SelectComponent.tsx
+++ b/components/SelectComponent.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import { Autocomplete } from "@mantine/core";
 
 /**
- * @param props.resourceType
+ * @param props include the string resourceType
  * @returns a component with a loading component, server error, or autocomplete select component populated with resource IDs
  */
 export default function SelectComponent(props) {
@@ -35,7 +35,7 @@ export default function SelectComponent(props) {
   return loadingRequest ? (
     <div>Loading content...</div>
   ) : !fetchingError && pageBody ? (
-    <PopulateIDHelper jsonBody={pageBody}></PopulateIDHelper>
+    <PopulateIDHelper jsonBody={pageBody} resourceType={resourceType}></PopulateIDHelper>
   ) : (
     <div>Problem connecting to server</div>
   );
@@ -45,11 +45,11 @@ export default function SelectComponent(props) {
  * @param props.jsonBody: fhirJson.Bundle
  * @returns a component with an error message that resources don't exist or autocomplete select component populated with resource IDs
  */
-function PopulateIDHelper(props: { jsonBody: fhirJson.Bundle }) {
+function PopulateIDHelper(props: { jsonBody: fhirJson.Bundle; resourceType: string }) {
   const entryArray = props.jsonBody.entry;
   console.log(entryArray);
   if (props.jsonBody.total && props.jsonBody.total > 0 && entryArray != undefined) {
-    return PopulateSelect(entryArray);
+    return PopulateSelect(entryArray, props.resourceType);
   } else {
     return <div> No resources found </div>;
   }
@@ -59,7 +59,7 @@ function PopulateIDHelper(props: { jsonBody: fhirJson.Bundle }) {
  * @param fhirJson.BundleEntry
  * @returns an autocomplete select component populated with resource IDs
  */
-const PopulateSelect = (entry: (fhirJson.BundleEntry | null)[]) => {
+const PopulateSelect = (entry: (fhirJson.BundleEntry | null)[], resourceType: string) => {
   const myArray = entry.map((el) => {
     return el?.resource ? `${el.resource.resourceType}/${el.resource.id}` : "";
   });
@@ -69,7 +69,7 @@ const PopulateSelect = (entry: (fhirJson.BundleEntry | null)[]) => {
     <Autocomplete
       value={value}
       onChange={setValue}
-      label="Select Practitioner"
+      label={`Select ${resourceType}`}
       placeholder="Start typing to see options"
       data={myArray}
       limit={10}

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -5,9 +5,9 @@ import { DateTime } from "luxon";
 import { textGray } from "../../../styles/appColors";
 import BackButton from "../../../components/BackButton";
 import MeasureDatePickers from "../../../components/MeasureDatePickers";
-
 const DEFAULT_PERIOD_START = new Date(`${DateTime.now().year}-01-01T00:00:00`);
 const DEFAULT_PERIOD_END = new Date(`${DateTime.now().year}-12-31T00:00:00`);
+import SelectComponent from "../../../components/SelectComponent";
 
 /**
  * EvaluateMeasurePage is a page that renders a back button and DatePickers that are pre-filled with
@@ -39,9 +39,9 @@ const EvaluateMeasurePage = () => {
           startOnUpdate={setPeriodStart}
           endOnUpdate={setPeriodEnd}
         />
-      </>
-    );
-  } else {
+        <SelectComponent resourceType="Practitioner"> </SelectComponent>
+      </> )
+      } else {
     //if resourceType is not a Measure, an error message is displayed
     return (
       <>

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -16,6 +16,7 @@ import SelectComponent from "../../../components/SelectComponent";
  * @returns React node with a back button and MeasureDatePickers if on a valid Measure url
  */
 const EvaluateMeasurePage = () => {
+  const [practitionerValue, setPractitionerValue] = useState("");
   const router = useRouter();
   const { resourceType, id } = router.query;
   const [periodStart, setPeriodStart] = useState<Date>(DEFAULT_PERIOD_START);
@@ -39,18 +40,21 @@ const EvaluateMeasurePage = () => {
           startOnUpdate={setPeriodStart}
           endOnUpdate={setPeriodEnd}
         />
-        <SelectComponent resourceType="Practitioner"/>
+          <SelectComponent
+            resourceType="Practitioner"
+            setPractitionerValue={setPractitionerValue}
+            practitionerValue={practitionerValue}
+        />
       </> )
       } else {
-    //if resourceType is not a Measure, an error message is displayed
-    return (
-      <>
-        <BackButton />
-        <Center>
-          <div>
-            Cannot evaluate on resourceType: {`${resourceType}`}, only on resourceType: Measure
-          </div>
-        </Center>
+        return (
+        <>
+          <BackButton />
+          <Center>
+            <div>
+              Cannot evaluate on resourceType: {`${resourceType}`}, only on resourceType: Measure
+            </div>
+          </Center>
       </>
     );
   }

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -40,21 +40,22 @@ const EvaluateMeasurePage = () => {
           startOnUpdate={setPeriodStart}
           endOnUpdate={setPeriodEnd}
         />
-          <SelectComponent
-            resourceType="Practitioner"
-            setValue={setPractitionerValue}
-            value={practitionerValue}
+        <SelectComponent
+          resourceType="Practitioner"
+          setValue={setPractitionerValue}
+          value={practitionerValue}
         />
-      </> )
-      } else {
-        return (
-        <>
-          <BackButton />
-          <Center>
-            <div>
-              Cannot evaluate on resourceType: {`${resourceType}`}, only on resourceType: Measure
-            </div>
-          </Center>
+      </>
+    );
+  } else {
+    return (
+      <>
+        <BackButton />
+        <Center>
+          <div>
+            Cannot evaluate on resourceType: {`${resourceType}`}, only on resourceType: Measure
+          </div>
+        </Center>
       </>
     );
   }

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -39,7 +39,7 @@ const EvaluateMeasurePage = () => {
           startOnUpdate={setPeriodStart}
           endOnUpdate={setPeriodEnd}
         />
-        <SelectComponent resourceType="Practitioner"> </SelectComponent>
+        <SelectComponent resourceType="Practitioner"/>
       </> )
       } else {
     //if resourceType is not a Measure, an error message is displayed

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -42,8 +42,8 @@ const EvaluateMeasurePage = () => {
         />
           <SelectComponent
             resourceType="Practitioner"
-            setPractitionerValue={setPractitionerValue}
-            practitionerValue={practitionerValue}
+            setValue={setPractitionerValue}
+            value={practitionerValue}
         />
       </> )
       } else {


### PR DESCRIPTION
## Summary
Implementation of reusable autocomplete component, which is currently used to select a practitioner for the evaluate measure page. When the user clicks on the autocomplete textbox, a list of up to 10 practitioners display and narrow down based on what the user types. 
## New behavior
On the Evaluate Measure page for a valid measure, an autocomplete component for a practitioner now appears. This enables the user to select an existing practitioner from the dropdown menu, which offers more specific options as the user types. _Note that the screen currently displays which option has been selected beneath the autocomplete component. This is to keep track of the state variable for later use._
## Code changes
- **pages/[resource]/[id]/SelectComponent**  defines an autocomplete textbox that provides a dropdown menu of all the resources of a given resourceType matching what the user types. 
- **pages/[resource]/[id]/evaluate.tsx**  renders autocomplete 
- **__tests__/pages/resource/id/evaluate.test.tsx**, unit tests added to file
-**__tests__/components/SelectComponent.test.tsx** unit tests added to file

## Testing Guidance
See the README.md for first time setup instructions.
#### Testing in browser: 
- To start the frontend: `npm run dev` then navigate to http://localhost:3001 in a browser
- Click on “Measure” from the left-hand-side navigation menu. Click on any of the IDs. Click on the “Evaluate Measure” button near the top right of the main page body.
- To test when no practitioners exist
  - First test the server when no practitioners exist. In this case, the webpage should display "No resources of type Practitioner found"
- To test when a practitioner does exist
  - Start by adding two new practitioners by clicking on the practitioner tab, then clicking the create new Practitioner button, then inputting a valid FHIR practitioner resource, and finally clicking submit. Return to the Evaluate Measure page using the steps above. Then complete the following three checks:
  - click on the textbox and verify that both resources display as part of a drop down menu
  - begin typing out one of the unique practitioner IDs and verify that the drop down menu now only displays the matching practitioner 
  - type something not contained in either practitioner ID to verify that the dropdown menu disappears where there are no matches. 
#### Unit testing: 
- Run the unit tests: `npm run test`