### PR TITLE
Radio select

### DIFF
--- a/__tests__/components/SelectComponent.test.tsx
+++ b/__tests__/components/SelectComponent.test.tsx
@@ -44,6 +44,16 @@ const RESOURCE_ID_BODY: fhirJson.Bundle = {
   ],
 };
 
+const NO_RESOURCE_ID: fhirJson.Bundle = {
+  resourceType: "Bundle",
+  meta: {
+    lastUpdated: "2022-06-23T19:52:58.721Z",
+  },
+  type: "searchset",
+  total: 0,
+  entry: [],
+};
+
 describe("Select component render", () => {
   beforeAll(() => {
     global.fetch = getMockFetchImplementation(RESOURCE_ID_BODY);
@@ -77,5 +87,22 @@ describe("Select component render", () => {
     expect(options[0].textContent).toBe("Practitioner/denom-EXM125-3");
     expect(options[1].textContent).toBe("Practitioner/numer-EXM125-3");
     screen.debug();
+  });
+});
+
+describe("Select component no practitioners", () => {
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementation(NO_RESOURCE_ID);
+  });
+
+  window.ResizeObserver = mockResizeObserver;
+  const user = userEvent.setup();
+
+  it("should display no practioners", async () => {
+    await act(async () => {
+      render(mantineRecoilWrap(<SelectComponent resourceType="Practitioner" />));
+    });
+
+    expect(screen.getByText("No resources of type Practitioner found")).toBeInTheDocument;
   });
 });

--- a/__tests__/components/SelectComponent.test.tsx
+++ b/__tests__/components/SelectComponent.test.tsx
@@ -63,11 +63,7 @@ describe("Select component no practitioners", () => {
     await act(async () => {
       render(
         mantineRecoilWrap(
-          <SelectComponent
-            resourceType="Practitioner"
-            practitionerValue=""
-            setPractitionerValue={jest.fn()}
-          />,
+          <SelectComponent resourceType="Practitioner" value="" setValue={jest.fn()} />,
         ),
       );
     });
@@ -86,11 +82,7 @@ describe("Select component render", () => {
     await act(async () => {
       render(
         mantineRecoilWrap(
-          <SelectComponent
-            resourceType="Practitioner"
-            practitionerValue=""
-            setPractitionerValue={jest.fn()}
-          />,
+          <SelectComponent resourceType="Practitioner" value="" setValue={jest.fn()} />,
         ),
       );
     });

--- a/__tests__/components/SelectComponent.test.tsx
+++ b/__tests__/components/SelectComponent.test.tsx
@@ -95,7 +95,6 @@ describe("Select component no practitioners", () => {
   });
 
   window.ResizeObserver = mockResizeObserver;
-  const user = userEvent.setup();
 
   it("should display no practioners", async () => {
     await act(async () => {

--- a/__tests__/components/SelectComponent.test.tsx
+++ b/__tests__/components/SelectComponent.test.tsx
@@ -7,7 +7,6 @@ import {
 } from "../helpers/testHelpers";
 import { fhirJson } from "@fhir-typescript/r4-core";
 import SelectComponent from "../../components/SelectComponent";
-import userEvent from "@testing-library/user-event";
 
 const RESOURCE_ID_BODY: fhirJson.Bundle = {
   resourceType: "Bundle",
@@ -54,19 +53,47 @@ const NO_RESOURCE_ID: fhirJson.Bundle = {
   entry: [],
 };
 
+describe("Select component no practitioners", () => {
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementation(NO_RESOURCE_ID);
+  });
+
+  window.ResizeObserver = mockResizeObserver;
+  it("should display no practioners", async () => {
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <SelectComponent
+            resourceType="Practitioner"
+            practitionerValue=""
+            setPractitionerValue={jest.fn()}
+          />,
+        ),
+      );
+    });
+  });
+  expect(screen.findByText("No resources of type Practitioner found")).toBeInTheDocument;
+});
+
 describe("Select component render", () => {
   beforeAll(() => {
     global.fetch = getMockFetchImplementation(RESOURCE_ID_BODY);
   });
 
   window.ResizeObserver = mockResizeObserver;
-  const user = userEvent.setup();
 
   it("should display a dropdown menu populated with resource ID's when prompted by user key presses", async () => {
     await act(async () => {
-      render(mantineRecoilWrap(<SelectComponent resourceType="Practitioner" />));
+      render(
+        mantineRecoilWrap(
+          <SelectComponent
+            resourceType="Practitioner"
+            practitionerValue=""
+            setPractitionerValue={jest.fn()}
+          />,
+        ),
+      );
     });
-
     //retrieves the combobox and the input field within the combobox
     const autocomplete = screen.getByRole("combobox");
     const input = within(autocomplete).getByRole("searchbox");
@@ -79,28 +106,9 @@ describe("Select component render", () => {
       fireEvent.keyDown(autocomplete, { key: "Enter" });
     });
 
-    //verifies that the input field updates appropriately
-    expect(input.getAttribute("value")).toBe("P");
-
     //verifies that the drop down autocomplete menu is populated with the resource IDs fetched from the server
     const options = screen.getAllByRole("option");
     expect(options[0].textContent).toBe("Practitioner/denom-EXM125-3");
     expect(options[1].textContent).toBe("Practitioner/numer-EXM125-3");
-  });
-});
-
-describe("Select component no practitioners", () => {
-  beforeAll(() => {
-    global.fetch = getMockFetchImplementation(NO_RESOURCE_ID);
-  });
-
-  window.ResizeObserver = mockResizeObserver;
-
-  it("should display no practioners", async () => {
-    await act(async () => {
-      render(mantineRecoilWrap(<SelectComponent resourceType="Practitioner" />));
-    });
-
-    expect(screen.getByText("No resources of type Practitioner found")).toBeInTheDocument;
   });
 });

--- a/__tests__/components/SelectComponent.test.tsx
+++ b/__tests__/components/SelectComponent.test.tsx
@@ -86,7 +86,6 @@ describe("Select component render", () => {
     const options = screen.getAllByRole("option");
     expect(options[0].textContent).toBe("Practitioner/denom-EXM125-3");
     expect(options[1].textContent).toBe("Practitioner/numer-EXM125-3");
-    screen.debug();
   });
 });
 

--- a/__tests__/components/SelectComponent.test.tsx
+++ b/__tests__/components/SelectComponent.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, act, within, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import {
+  mantineRecoilWrap,
+  getMockFetchImplementation,
+  mockResizeObserver,
+} from "../helpers/testHelpers";
+import { fhirJson } from "@fhir-typescript/r4-core";
+import SelectComponent from "../../components/SelectComponent";
+import userEvent from "@testing-library/user-event";
+
+const RESOURCE_ID_BODY: fhirJson.Bundle = {
+  resourceType: "Bundle",
+  meta: {
+    lastUpdated: "2022-06-23T19:52:58.721Z",
+  },
+  type: "searchset",
+  total: 2,
+  entry: [
+    {
+      fullUrl: "http://localhost:3000/4_0_1/DiagnosticReport/denom-EXM125-3",
+      resource: {
+        resourceType: "Practitioner",
+        id: "denom-EXM125-3",
+        meta: {
+          profile: [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note",
+          ],
+        },
+      },
+    },
+    {
+      fullUrl: "http://localhost:3000/4_0_1/DiagnosticReport/numer-EXM125-3",
+      resource: {
+        resourceType: "Practitioner",
+        id: "numer-EXM125-3",
+        meta: {
+          profile: [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note",
+          ],
+        },
+      },
+    },
+  ],
+};
+
+describe("Select component render", () => {
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementation(RESOURCE_ID_BODY);
+  });
+
+  window.ResizeObserver = mockResizeObserver;
+  const user = userEvent.setup();
+
+  it("should display a dropdown menu populated with resource ID's when prompted by user key presses", async () => {
+    await act(async () => {
+      render(mantineRecoilWrap(<SelectComponent resourceType="Practitioner" />));
+    });
+
+    //retrieves the combobox and the input field within the combobox
+    const autocomplete = screen.getByRole("combobox");
+    const input = within(autocomplete).getByRole("searchbox");
+    autocomplete.focus();
+
+    //mocks user key clicks to test the input fields and drop down menus
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "P" } });
+      fireEvent.keyDown(autocomplete, { key: "ArrowDown" });
+      fireEvent.keyDown(autocomplete, { key: "Enter" });
+    });
+
+    //verifies that the input field updates appropriately
+    expect(input.getAttribute("value")).toBe("P");
+
+    //verifies that the drop down autocomplete menu is populated with the resource IDs fetched from the server
+    const options = screen.getAllByRole("option");
+    expect(options[0].textContent).toBe("Practitioner/denom-EXM125-3");
+    expect(options[1].textContent).toBe("Practitioner/numer-EXM125-3");
+    screen.debug();
+  });
+});

--- a/__tests__/pages/resource/id/evaluate.test.tsx
+++ b/__tests__/pages/resource/id/evaluate.test.tsx
@@ -1,10 +1,49 @@
 import { render, screen, act } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { createMockRouter } from "../../../helpers/testHelpers";
+import { createMockRouter, getMockFetchImplementation } from "../../../helpers/testHelpers";
 import { RouterContext } from "next/dist/shared/lib/router-context";
 import EvaluateMeasurePage from "../../../../pages/[resourceType]/[id]/evaluate";
+import { fhirJson } from "@fhir-typescript/r4-core";
+
+const RESOURCE_ID_BODY: fhirJson.Bundle = {
+  resourceType: "Bundle",
+  meta: {
+    lastUpdated: "2022-06-23T19:52:58.721Z",
+  },
+  type: "searchset",
+  total: 2,
+  entry: [
+    {
+      fullUrl: "http://localhost:3000/4_0_1/DiagnosticReport/denom-EXM125-3",
+      resource: {
+        resourceType: "Practitioner",
+        id: "denom-EXM125-3",
+        meta: {
+          profile: [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note",
+          ],
+        },
+      },
+    },
+    {
+      fullUrl: "http://localhost:3000/4_0_1/DiagnosticReport/numer-EXM125-3",
+      resource: {
+        resourceType: "Practitioner",
+        id: "numer-EXM125-3",
+        meta: {
+          profile: [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note",
+          ],
+        },
+      },
+    },
+  ],
+};
 
 describe("Test evaluate page render for measure", () => {
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementation(RESOURCE_ID_BODY);
+  });
   it("should display expected text", async () => {
     await act(async () => {
       render(
@@ -18,11 +57,14 @@ describe("Test evaluate page render for measure", () => {
       );
     });
 
-    expect(screen.getByText(/Coming soon.../)).toBeInTheDocument();
+    expect(screen.getByText("Select Practitioner")).toBeInTheDocument();
   });
 });
 
 describe("Test evaluate page render for non-measure", () => {
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementation(RESOURCE_ID_BODY);
+  });
   it("should display an error message", async () => {
     await act(async () => {
       render(

--- a/__tests__/pages/resource/id/evaluate.test.tsx
+++ b/__tests__/pages/resource/id/evaluate.test.tsx
@@ -110,6 +110,7 @@ describe("Select component render", () => {
         </RouterContext.Provider>,
       );
     });
+    
     // //retrieves the combobox and the input field within the combobox
     const radio = screen.getByLabelText("Subject");
     await act(async () => {

--- a/__tests__/pages/resource/id/evaluate.test.tsx
+++ b/__tests__/pages/resource/id/evaluate.test.tsx
@@ -1,7 +1,6 @@
-import { render, screen, act, within, fireEvent } from "@testing-library/react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import {
-  mantineRecoilWrap,
   getMockFetchImplementation,
   mockResizeObserver,
   createMockRouter,
@@ -91,14 +90,14 @@ describe("Test evaluate page render for non-measure", () => {
   });
 });
 
-describe("Select component render", () => {
+describe("Radio button render subject", () => {
   beforeAll(() => {
     global.fetch = getMockFetchImplementation(RESOURCE_ID_BODY);
   });
 
   window.ResizeObserver = mockResizeObserver;
 
-  it("should display a dropdown menu populated with resource ID's when prompted by user key presses", async () => {
+  it("should display an autocomplete component when the subject radio is selected", async () => {
     await act(async () => {
       render(
         <RouterContext.Provider
@@ -110,24 +109,24 @@ describe("Select component render", () => {
         </RouterContext.Provider>,
       );
     });
-    
-    // //retrieves the combobox and the input field within the combobox
-    const radio = screen.getByLabelText("Subject");
+
+    // click the subject radio button to ensure an autocomplete component appears
+    const subjectRadio = screen.getByLabelText("Subject");
     await act(async () => {
-      fireEvent.click(radio);
+      fireEvent.click(subjectRadio);
     });
     expect(screen.getByText("Select Patient")).toBeInTheDocument;
   });
 });
 
-describe("Select component render1", () => {
+describe("Radio button render population", () => {
   beforeAll(() => {
     global.fetch = getMockFetchImplementation(RESOURCE_ID_BODY);
   });
 
   window.ResizeObserver = mockResizeObserver;
 
-  it("should display a dropdown menu populated with resource ID's when prompted by user key presses1", async () => {
+  it("should not display an autocomplete component when the population radio is selected", async () => {
     await act(async () => {
       render(
         <RouterContext.Provider
@@ -140,13 +139,11 @@ describe("Select component render1", () => {
       );
     });
 
-    // //retrieves the combobox and the input field within the combobox
-    const radio2 = screen.getByLabelText("Population");
-    // const radio = screen.getByLabelText("radio");
+    // click the population radio button to ensure an autocomplete component doesn't appear
+    const populationRadio = screen.getByLabelText("Population");
     await act(async () => {
-      fireEvent.click(radio2);
+      fireEvent.click(populationRadio);
     });
     expect(screen.findByText("Select Patient")).not.toBeInTheDocument;
   });
 });
-

--- a/__tests__/pages/resource/id/evaluate.test.tsx
+++ b/__tests__/pages/resource/id/evaluate.test.tsx
@@ -1,6 +1,11 @@
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, within, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { createMockRouter, getMockFetchImplementation } from "../../../helpers/testHelpers";
+import {
+  mantineRecoilWrap,
+  getMockFetchImplementation,
+  mockResizeObserver,
+  createMockRouter,
+} from "../../../helpers/testHelpers";
 import { RouterContext } from "next/dist/shared/lib/router-context";
 import EvaluateMeasurePage from "../../../../pages/[resourceType]/[id]/evaluate";
 import { fhirJson } from "@fhir-typescript/r4-core";
@@ -85,3 +90,62 @@ describe("Test evaluate page render for non-measure", () => {
     ).toBeInTheDocument();
   });
 });
+
+describe("Select component render", () => {
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementation(RESOURCE_ID_BODY);
+  });
+
+  window.ResizeObserver = mockResizeObserver;
+
+  it("should display a dropdown menu populated with resource ID's when prompted by user key presses", async () => {
+    await act(async () => {
+      render(
+        <RouterContext.Provider
+          value={createMockRouter({
+            query: { resourceType: "Measure", id: "Measure-12" },
+          })}
+        >
+          <EvaluateMeasurePage />
+        </RouterContext.Provider>,
+      );
+    });
+    // //retrieves the combobox and the input field within the combobox
+    const radio = screen.getByLabelText("Subject");
+    await act(async () => {
+      fireEvent.click(radio);
+    });
+    expect(screen.getByText("Select Patient")).toBeInTheDocument;
+  });
+});
+
+describe("Select component render1", () => {
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementation(RESOURCE_ID_BODY);
+  });
+
+  window.ResizeObserver = mockResizeObserver;
+
+  it("should display a dropdown menu populated with resource ID's when prompted by user key presses1", async () => {
+    await act(async () => {
+      render(
+        <RouterContext.Provider
+          value={createMockRouter({
+            query: { resourceType: "Measure", id: "Measure-12" },
+          })}
+        >
+          <EvaluateMeasurePage />
+        </RouterContext.Provider>,
+      );
+    });
+
+    // //retrieves the combobox and the input field within the combobox
+    const radio2 = screen.getByLabelText("Population");
+    // const radio = screen.getByLabelText("radio");
+    await act(async () => {
+      fireEvent.click(radio2);
+    });
+    expect(screen.findByText("Select Patient")).not.toBeInTheDocument;
+  });
+});
+

--- a/components/SelectComponent.tsx
+++ b/components/SelectComponent.tsx
@@ -47,7 +47,6 @@ export default function SelectComponent(props) {
  */
 function PopulateIDHelper(props: { jsonBody: fhirJson.Bundle; resourceType: string }) {
   const entryArray = props.jsonBody.entry;
-  console.log(entryArray);
   if (props.jsonBody.total && props.jsonBody.total > 0 && entryArray != undefined) {
     return PopulateSelect(entryArray, props.resourceType);
   } else {

--- a/components/SelectComponent.tsx
+++ b/components/SelectComponent.tsx
@@ -1,12 +1,16 @@
 import { fhirJson } from "@fhir-typescript/r4-core";
-import { useState, useEffect } from "react";
+import { useState, useEffect, Dispatch, SetStateAction } from "react";
 import { Autocomplete } from "@mantine/core";
 
 /**
  * @param props include the string resourceType
  * @returns a component with a loading component, server error, or autocomplete select component populated with resource IDs
  */
-export default function SelectComponent(props: { resourceType: string }) {
+export default function SelectComponent(props: {
+  resourceType: string;
+  setPractitionerValue: Dispatch<SetStateAction<string>>;
+  practitionerValue: string;
+}) {
   const resourceType = props.resourceType;
   const [pageBody, setPageBody] = useState<fhirJson.Bundle>();
   const [fetchingError, setFetchingError] = useState(false);
@@ -14,7 +18,6 @@ export default function SelectComponent(props: { resourceType: string }) {
 
   useEffect(() => {
     if (resourceType) {
-      //setLoadingRequest(true);
       fetch(`${process.env.NEXT_PUBLIC_DEQM_SERVER}/${resourceType}`)
         .then((data) => {
           return data.json() as Promise<fhirJson.Bundle>;
@@ -35,7 +38,12 @@ export default function SelectComponent(props: { resourceType: string }) {
   return loadingRequest ? (
     <div>Loading content...</div>
   ) : !fetchingError && pageBody ? (
-    <PopulateIDHelper jsonBody={pageBody} resourceType={resourceType}></PopulateIDHelper>
+    <PopulateIDHelper
+      jsonBody={pageBody}
+      resourceType={resourceType}
+      setPractitionerValue={props.setPractitionerValue}
+      practitionerValue={props.practitionerValue}
+    ></PopulateIDHelper>
   ) : (
     <div>Problem connecting to server</div>
   );
@@ -45,10 +53,20 @@ export default function SelectComponent(props: { resourceType: string }) {
  * @param props include a fhirJson.Bundle jsonBody, and a string resourceType
  * @returns a component with an error message that resources don't exist or autocomplete select component populated with resource IDs
  */
-function PopulateIDHelper(props: { jsonBody: fhirJson.Bundle; resourceType: string }) {
+function PopulateIDHelper(props: {
+  jsonBody: fhirJson.Bundle;
+  resourceType: string;
+  setPractitionerValue: Dispatch<SetStateAction<string>>;
+  practitionerValue: string;
+}) {
   const entryArray = props.jsonBody.entry;
   if (props.jsonBody.total && props.jsonBody.total > 0 && entryArray != undefined) {
-    return PopulateSelect(entryArray, props.resourceType);
+    return PopulateSelect(
+      entryArray,
+      props.resourceType,
+      props.setPractitionerValue,
+      props.practitionerValue,
+    );
   } else {
     return <div> {`No resources of type ${props.resourceType} found`} </div>;
   }
@@ -58,16 +76,20 @@ function PopulateIDHelper(props: { jsonBody: fhirJson.Bundle; resourceType: stri
  * @param fhirJson.BundleEntry
  * @returns an autocomplete select component populated with resource IDs
  */
-const PopulateSelect = (entry: (fhirJson.BundleEntry | null)[], resourceType: string) => {
+const PopulateSelect = (
+  entry: (fhirJson.BundleEntry | null)[],
+  resourceType: string,
+  setPractitionerValue: Dispatch<SetStateAction<string>>,
+  practitionerValue: string,
+) => {
   const myArray = entry.map((el) => {
     return el?.resource ? `${el.resource.resourceType}/${el.resource.id}` : "";
   });
-  const [value, setValue] = useState("");
 
   return (
     <Autocomplete
-      value={value}
-      onChange={setValue}
+      value={practitionerValue}
+      onChange={setPractitionerValue}
       label={`Select ${resourceType}`}
       placeholder="Start typing to see options"
       data={myArray}

--- a/components/SelectComponent.tsx
+++ b/components/SelectComponent.tsx
@@ -6,7 +6,7 @@ import { Autocomplete } from "@mantine/core";
  * @param props include the string resourceType
  * @returns a component with a loading component, server error, or autocomplete select component populated with resource IDs
  */
-export default function SelectComponent(props) {
+export default function SelectComponent(props: { resourceType: string }) {
   const resourceType = props.resourceType;
   const [pageBody, setPageBody] = useState<fhirJson.Bundle>();
   const [fetchingError, setFetchingError] = useState(false);

--- a/components/SelectComponent.tsx
+++ b/components/SelectComponent.tsx
@@ -42,7 +42,7 @@ export default function SelectComponent(props) {
 }
 
 /**
- * @param props.jsonBody: fhirJson.Bundle
+ * @param props include a fhirJson.Bundle jsonBody, and a string resourceType
  * @returns a component with an error message that resources don't exist or autocomplete select component populated with resource IDs
  */
 function PopulateIDHelper(props: { jsonBody: fhirJson.Bundle; resourceType: string }) {
@@ -51,7 +51,7 @@ function PopulateIDHelper(props: { jsonBody: fhirJson.Bundle; resourceType: stri
   if (props.jsonBody.total && props.jsonBody.total > 0 && entryArray != undefined) {
     return PopulateSelect(entryArray, props.resourceType);
   } else {
-    return <div> No resources found </div>;
+    return <div> {`No resources of type ${props.resourceType} found`} </div>;
   }
 }
 

--- a/components/SelectComponent.tsx
+++ b/components/SelectComponent.tsx
@@ -1,0 +1,78 @@
+import { fhirJson } from "@fhir-typescript/r4-core";
+import { useState, useEffect } from "react";
+import { Autocomplete } from "@mantine/core";
+
+/**
+ * @param props.resourceType
+ * @returns a component with a loading component, server error, or autocomplete select component populated with resource IDs
+ */
+export default function SelectComponent(props) {
+  const resourceType = props.resourceType;
+  const [pageBody, setPageBody] = useState<fhirJson.Bundle>();
+  const [fetchingError, setFetchingError] = useState(false);
+  const [loadingRequest, setLoadingRequest] = useState(false);
+
+  useEffect(() => {
+    if (resourceType) {
+      //setLoadingRequest(true);
+      fetch(`${process.env.NEXT_PUBLIC_DEQM_SERVER}/${resourceType}`)
+        .then((data) => {
+          return data.json() as Promise<fhirJson.Bundle>;
+        })
+        .then((resourcePageBody) => {
+          setPageBody(resourcePageBody);
+          setFetchingError(false);
+          setLoadingRequest(false);
+        })
+        .catch((error) => {
+          console.log(error.message);
+          setFetchingError(true);
+          setLoadingRequest(false);
+        });
+    }
+  }, [resourceType]);
+
+  return loadingRequest ? (
+    <div>Loading content...</div>
+  ) : !fetchingError && pageBody ? (
+    <PopulateIDHelper jsonBody={pageBody}></PopulateIDHelper>
+  ) : (
+    <div>Problem connecting to server</div>
+  );
+}
+
+/**
+ * @param props.jsonBody: fhirJson.Bundle
+ * @returns a component with an error message that resources don't exist or autocomplete select component populated with resource IDs
+ */
+function PopulateIDHelper(props: { jsonBody: fhirJson.Bundle }) {
+  const entryArray = props.jsonBody.entry;
+  console.log(entryArray);
+  if (props.jsonBody.total && props.jsonBody.total > 0 && entryArray != undefined) {
+    return PopulateSelect(entryArray);
+  } else {
+    return <div> No resources found </div>;
+  }
+}
+
+/**
+ * @param fhirJson.BundleEntry
+ * @returns an autocomplete select component populated with resource IDs
+ */
+const PopulateSelect = (entry: (fhirJson.BundleEntry | null)[]) => {
+  const myArray = entry.map((el) => {
+    return el?.resource ? `${el.resource.resourceType}/${el.resource.id}` : "";
+  });
+  const [value, setValue] = useState("");
+
+  return (
+    <Autocomplete
+      value={value}
+      onChange={setValue}
+      label="Select Practitioner"
+      placeholder="Start typing to see options"
+      data={myArray}
+      limit={10}
+    />
+  );
+};

--- a/components/SelectComponent.tsx
+++ b/components/SelectComponent.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import { Autocomplete } from "@mantine/core";
 
 /**
- * @param props.resourceType
+ * @param props include the string resourceType
  * @returns a component with a loading component, server error, or autocomplete select component populated with resource IDs
  */
 export default function SelectComponent(props) {
@@ -35,7 +35,7 @@ export default function SelectComponent(props) {
   return loadingRequest ? (
     <div>Loading content...</div>
   ) : !fetchingError && pageBody ? (
-    <PopulateIDHelper jsonBody={pageBody}></PopulateIDHelper>
+    <PopulateIDHelper jsonBody={pageBody} resourceType={resourceType}></PopulateIDHelper>
   ) : (
     <div>Problem connecting to server</div>
   );
@@ -45,11 +45,11 @@ export default function SelectComponent(props) {
  * @param props.jsonBody: fhirJson.Bundle
  * @returns a component with an error message that resources don't exist or autocomplete select component populated with resource IDs
  */
-function PopulateIDHelper(props: { jsonBody: fhirJson.Bundle }) {
+function PopulateIDHelper(props: { jsonBody: fhirJson.Bundle; resourceType: string }) {
   const entryArray = props.jsonBody.entry;
   console.log(entryArray);
   if (props.jsonBody.total && props.jsonBody.total > 0 && entryArray != undefined) {
-    return PopulateSelect(entryArray);
+    return PopulateSelect(entryArray, props.resourceType);
   } else {
     return <div> No resources found </div>;
   }
@@ -59,7 +59,7 @@ function PopulateIDHelper(props: { jsonBody: fhirJson.Bundle }) {
  * @param fhirJson.BundleEntry
  * @returns an autocomplete select component populated with resource IDs
  */
-const PopulateSelect = (entry: (fhirJson.BundleEntry | null)[]) => {
+const PopulateSelect = (entry: (fhirJson.BundleEntry | null)[], resourceType: string) => {
   const myArray = entry.map((el) => {
     return el?.resource ? `${el.resource.resourceType}/${el.resource.id}` : "";
   });
@@ -69,7 +69,7 @@ const PopulateSelect = (entry: (fhirJson.BundleEntry | null)[]) => {
     <Autocomplete
       value={value}
       onChange={setValue}
-      label="Select Practitioner"
+      label={`Select ${resourceType}`}
       placeholder="Start typing to see options"
       data={myArray}
       limit={10}

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -29,16 +29,12 @@ const EvaluateMeasurePage = () => {
         </RadioGroup>
         {/* only displays autocomplete component if radio value is Patient */}
         {radioValue === "Subject" ? (
-          <SelectComponent
-            resourceType="Patient"
-            setPractitionerValue={setPatientValue}
-            practitionerValue={patientValue}
-          />
+          <SelectComponent resourceType="Patient" setValue={setPatientValue} value={patientValue} />
         ) : null}
         <SelectComponent
           resourceType="Practitioner"
-          setPractitionerValue={setPractitionerValue}
-          practitionerValue={practitionerValue}
+          setValue={setPractitionerValue}
+          value={practitionerValue}
         />
       </div>
     );

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -1,6 +1,8 @@
 import { Center } from "@mantine/core";
 import { useRouter } from "next/router";
 import SelectComponent from "../../../components/SelectComponent";
+import { useState, useEffect } from "react";
+import { RadioGroup, Radio } from "@mantine/core";
 
 /**
  * Page for evaluate measure functionality.
@@ -9,10 +11,27 @@ import SelectComponent from "../../../components/SelectComponent";
 const EvaluateMeasurePage = () => {
   const router = useRouter();
   const { resourceType } = router.query;
+  const [value, setValue] = useState("react");
+  useEffect(() => {
+    console.log(value);
+    //if (value === subject)
+    <div style={{ margin: "30px" }}></div>;
+  }, [value]);
+
   if (resourceType === "Measure") {
     return (
       <div>
-        {" "}
+        <RadioGroup
+          value={value}
+          onChange={setValue}
+          label="Select your favorite framework/library"
+          description="This is anonymous"
+          required
+        >
+          <Radio value="Subject" label="Subject" />
+          <Radio value="Population" label="Population" />
+        </RadioGroup>
+        {value === "Subject" ? <SelectComponent resourceType="Patient"></SelectComponent> : null}
         <SelectComponent resourceType="Practitioner"> </SelectComponent>
       </div>
     );

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -12,6 +12,8 @@ const EvaluateMeasurePage = () => {
   const router = useRouter();
   const { resourceType } = router.query;
   const [radioValue, setRadioValue] = useState("react");
+  const [practitionerValue, setPractitionerValue] = useState("");
+  const [patientValue, setPatientValue] = useState("");
 
   if (resourceType === "Measure") {
     return (
@@ -27,10 +29,17 @@ const EvaluateMeasurePage = () => {
         </RadioGroup>
         {/* only displays autocomplete component if radio value is Patient */}
         {radioValue === "Subject" ? (
-          <SelectComponent resourceType="Patient"></SelectComponent>
+          <SelectComponent
+            resourceType="Patient"
+            setPractitionerValue={setPatientValue}
+            practitionerValue={patientValue}
+          />
         ) : null}
-
-        <SelectComponent resourceType="Practitioner" />
+        <SelectComponent
+          resourceType="Practitioner"
+          setPractitionerValue={setPractitionerValue}
+          practitionerValue={practitionerValue}
+        />
       </div>
     );
   } else {

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -1,7 +1,7 @@
 import { Center } from "@mantine/core";
 import { useRouter } from "next/router";
 import SelectComponent from "../../../components/SelectComponent";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { RadioGroup, Radio } from "@mantine/core";
 
 /**
@@ -11,28 +11,26 @@ import { RadioGroup, Radio } from "@mantine/core";
 const EvaluateMeasurePage = () => {
   const router = useRouter();
   const { resourceType } = router.query;
-  const [value, setValue] = useState("react");
-  useEffect(() => {
-    console.log(value);
-    //if (value === subject)
-    <div style={{ margin: "30px" }}></div>;
-  }, [value]);
+  const [radioValue, setRadioValue] = useState("react");
 
   if (resourceType === "Measure") {
     return (
       <div>
         <RadioGroup
-          value={value}
-          onChange={setValue}
-          label="Select your favorite framework/library"
-          description="This is anonymous"
+          value={radioValue}
+          onChange={setRadioValue}
+          label="Select Subject or Population"
           required
         >
           <Radio value="Subject" label="Subject" />
           <Radio value="Population" label="Population" />
         </RadioGroup>
-        {value === "Subject" ? <SelectComponent resourceType="Patient"></SelectComponent> : null}
-        <SelectComponent resourceType="Practitioner"> </SelectComponent>
+        {/* only displays autocomplete component if radio value is Patient */}
+        {radioValue === "Subject" ? (
+          <SelectComponent resourceType="Patient"></SelectComponent>
+        ) : null}
+
+        <SelectComponent resourceType="Practitioner" />
       </div>
     );
   } else {

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -1,5 +1,6 @@
 import { Center } from "@mantine/core";
 import { useRouter } from "next/router";
+import SelectComponent from "../../../components/SelectComponent";
 
 /**
  * Page for evaluate measure functionality.
@@ -9,7 +10,12 @@ const EvaluateMeasurePage = () => {
   const router = useRouter();
   const { resourceType } = router.query;
   if (resourceType === "Measure") {
-    return <div>Coming soon...</div>;
+    return (
+      <div>
+        {" "}
+        <SelectComponent resourceType="Practitioner"> </SelectComponent>
+      </div>
+    );
   } else {
     return (
       <Center>


### PR DESCRIPTION
## Summary
Adds a radioGroup to the Evaluate Measure page with two radio options, subject and population. If the user selects the subject option, an autocomplete component is rendered on the page. If the user selects the population option, no new components are rendered. 
## New behavior
On the Evaluate Measure page for a valid measure, a radioGroup is now rendered, allowing the user to choose either subject or population. An autocomplete component is conditionally rendered if the user selects the subject radio button, otherwise there are no changes.  
## Code changes
- **pages/[resource]/[id]/SelectComponent**  adds a state variable to keep track of autocomplete value changes
- **pages/[resource]/[id]/evaluate.tsx**  renders radioGroup
- **__tests__/pages/resource/id/evaluate.test.tsx**, unit tests added to file
- - **__tests__/pages/resource/id/SelectComponent.test.tsx**, unit tests added to file

## Testing Guidance
See the README.md for first time setup instructions.
#### Testing in browser: 
- To start the frontend: `npm run dev` then navigate to http://localhost:3001 in a browser
- Click on “Measure” from the left-hand-side navigation menu. Click on any of the IDs. Click on the “Evaluate Measure” button near the top right of the main page body.
- To test the subject radio button
  - Click the subject option. A Patient autocomplete component should appear.
- To test the population button
  - Click the population option. No Patient autocomplete component should appear. If there was one previously, it should disappear. Note that the Practitioner autocomplete component is unrelated and should not change regardless of which option is selected. 
#### Unit testing: 
- Run the unit tests: `npm run test`