### PR TITLE
Radio group

### DIFF
--- a/__tests__/components/SelectComponent.test.tsx
+++ b/__tests__/components/SelectComponent.test.tsx
@@ -93,6 +93,9 @@ describe("Select component render", () => {
     const input = within(autocomplete).getByRole("searchbox");
     autocomplete.focus();
 
+    //SelectComponent should not be required
+    expect(input).not.toBeRequired();
+
     //mocks user key clicks to test the input fields and drop down menus
     await act(async () => {
       fireEvent.change(input, { target: { value: "P" } });
@@ -104,5 +107,22 @@ describe("Select component render", () => {
     const options = screen.getAllByRole("option");
     expect(options[0].textContent).toBe("Practitioner/denom-EXM125-3");
     expect(options[1].textContent).toBe("Practitioner/numer-EXM125-3");
+  });
+
+  it("tests for SelectComponent that is required", async () => {
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <SelectComponent
+            resourceType="Practitioner"
+            value=""
+            setValue={jest.fn()}
+            required={true}
+          />,
+        ),
+      );
+    });
+
+    expect(within(screen.getByRole("combobox")).getByRole("searchbox")).toBeRequired();
   });
 });

--- a/__tests__/pages/resource/id/evaluate.test.tsx
+++ b/__tests__/pages/resource/id/evaluate.test.tsx
@@ -374,3 +374,55 @@ describe("Select component render", () => {
     expect(options[1].textContent).toBe("Practitioner/numer-EXM125-3");
   });
 });
+
+describe("Radio button render subject", () => {
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementation(RESOURCE_ID_BODY);
+  });
+  window.ResizeObserver = mockResizeObserver;
+  it("should display an autocomplete component when the subject radio is selected", async () => {
+    await act(async () => {
+      render(
+        <RouterContext.Provider
+          value={createMockRouter({
+            query: { resourceType: "Measure", id: "Measure-12" },
+          })}
+        >
+          <EvaluateMeasurePage />
+        </RouterContext.Provider>,
+      );
+    });
+    // click the subject radio button to ensure an autocomplete component appears
+    const subjectRadio = screen.getByLabelText("Subject");
+    await act(async () => {
+      fireEvent.click(subjectRadio);
+    });
+    expect(screen.getByText("Select Patient")).toBeInTheDocument;
+  });
+});
+
+describe("Radio button render population", () => {
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementation(RESOURCE_ID_BODY);
+  });
+  window.ResizeObserver = mockResizeObserver;
+  it("should not display an autocomplete component when the population radio is selected", async () => {
+    await act(async () => {
+      render(
+        <RouterContext.Provider
+          value={createMockRouter({
+            query: { resourceType: "Measure", id: "Measure-12" },
+          })}
+        >
+          <EvaluateMeasurePage />
+        </RouterContext.Provider>,
+      );
+    });
+    // click the population radio button to ensure an autocomplete component doesn't appear
+    const populationRadio = screen.getByLabelText("Population");
+    await act(async () => {
+      fireEvent.click(populationRadio);
+    });
+    expect(screen.findByText("Select Patient")).not.toBeInTheDocument;
+  });
+});

--- a/__tests__/pages/resource/id/evaluate.test.tsx
+++ b/__tests__/pages/resource/id/evaluate.test.tsx
@@ -392,11 +392,9 @@ describe("Radio button render subject", () => {
         </RouterContext.Provider>,
       );
     });
-    // click the subject radio button to ensure an autocomplete component appears
+    // Subject radio button should be pre-selected, so Select Patient component should appear
     const subjectRadio = screen.getByLabelText("Subject");
-    await act(async () => {
-      fireEvent.click(subjectRadio);
-    });
+    expect(subjectRadio).toBeChecked();
     expect(screen.getByText("Select Patient")).toBeInTheDocument;
   });
 });
@@ -420,6 +418,8 @@ describe("Radio button render population", () => {
     });
     // click the population radio button to ensure an autocomplete component doesn't appear
     const populationRadio = screen.getByLabelText("Population");
+    //Population radio button should not be pre-selected
+    expect(populationRadio).not.toBeChecked();
     await act(async () => {
       fireEvent.click(populationRadio);
     });

--- a/components/SelectComponent.tsx
+++ b/components/SelectComponent.tsx
@@ -13,13 +13,19 @@ export interface SelectComponentProps {
   setValue: Dispatch<SetStateAction<string>>;
   value: string;
   jsonBody?: fhirJson.Bundle;
+  required?: boolean;
 }
 
 /**
  * @param props include the type interface SelectComponentProps
  * @returns a component with a loading component, server error, or autocomplete select component populated with resource IDs
  */
-export default function SelectComponent({ resourceType, setValue, value }: SelectComponentProps) {
+export default function SelectComponent({
+  resourceType,
+  setValue,
+  value,
+  required,
+}: SelectComponentProps) {
   const [responseBody, setResponseBody] = useState<fhirJson.Bundle>();
   const [fetchingError, setFetchingError] = useState(false);
   const [loadingRequest, setLoadingRequest] = useState(false);
@@ -51,13 +57,20 @@ export default function SelectComponent({ resourceType, setValue, value }: Selec
       resourceType={resourceType}
       setValue={setValue}
       value={value}
+      required={required}
     />
   ) : (
     <div>Problem connecting to server</div>
   );
 }
 
-function PopulateIDHelper({ resourceType, setValue, value, jsonBody }: SelectComponentProps) {
+function PopulateIDHelper({
+  resourceType,
+  setValue,
+  value,
+  jsonBody,
+  required,
+}: SelectComponentProps) {
   const entryArray = jsonBody?.entry;
 
   //makes sure there are resources to display in the dropdown
@@ -73,6 +86,7 @@ function PopulateIDHelper({ resourceType, setValue, value, jsonBody }: SelectCom
         placeholder="Start typing to see options"
         data={myArray}
         limit={10}
+        required={required ? required : false}
       />
     );
   } else {

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -19,7 +19,7 @@ const DEFAULT_PERIOD_END = new Date(`${DateTime.now().year}-12-31T00:00:00`);
 const EvaluateMeasurePage = () => {
   const router = useRouter();
   const { resourceType, id } = router.query;
-  const [radioValue, setRadioValue] = useState("react");
+  const [radioValue, setRadioValue] = useState("Subject");
   const [practitionerValue, setPractitionerValue] = useState("");
   const [patientValue, setPatientValue] = useState("");
   const [periodStart, setPeriodStart] = useState<Date>(DEFAULT_PERIOD_START);
@@ -54,7 +54,12 @@ const EvaluateMeasurePage = () => {
         </RadioGroup>
         {/* only displays autocomplete component if radio value is Patient */}
         {radioValue === "Subject" ? (
-          <SelectComponent resourceType="Patient" setValue={setPatientValue} value={patientValue} />
+          <SelectComponent
+            resourceType="Patient"
+            setValue={setPatientValue}
+            value={patientValue}
+            required={true}
+          />
         ) : null}
         <SelectComponent
           resourceType="Practitioner"

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -1,13 +1,14 @@
-import { Center, Divider } from "@mantine/core";
+import { Center, Divider, RadioGroup, Radio } from "@mantine/core";
 import { useRouter } from "next/router";
 import React, { useState } from "react";
 import { DateTime } from "luxon";
 import { textGray } from "../../../styles/appColors";
 import BackButton from "../../../components/BackButton";
+import SelectComponent from "../../../components/SelectComponent";
 import MeasureDatePickers from "../../../components/MeasureDatePickers";
+
 const DEFAULT_PERIOD_START = new Date(`${DateTime.now().year}-01-01T00:00:00`);
 const DEFAULT_PERIOD_END = new Date(`${DateTime.now().year}-12-31T00:00:00`);
-import SelectComponent from "../../../components/SelectComponent";
 
 /**
  * EvaluateMeasurePage is a page that renders a back button and DatePickers that are pre-filled with
@@ -16,9 +17,11 @@ import SelectComponent from "../../../components/SelectComponent";
  * @returns React node with a back button and MeasureDatePickers if on a valid Measure url
  */
 const EvaluateMeasurePage = () => {
-  const [practitionerValue, setPractitionerValue] = useState("");
   const router = useRouter();
   const { resourceType, id } = router.query;
+  const [radioValue, setRadioValue] = useState("react");
+  const [practitionerValue, setPractitionerValue] = useState("");
+  const [patientValue, setPatientValue] = useState("");
   const [periodStart, setPeriodStart] = useState<Date>(DEFAULT_PERIOD_START);
   const [periodEnd, setPeriodEnd] = useState<Date>(DEFAULT_PERIOD_END);
 
@@ -40,6 +43,19 @@ const EvaluateMeasurePage = () => {
           startOnUpdate={setPeriodStart}
           endOnUpdate={setPeriodEnd}
         />
+        <RadioGroup
+          value={radioValue}
+          onChange={setRadioValue}
+          label="Select Subject or Population"
+          required
+        >
+          <Radio value="Subject" label="Subject" />
+          <Radio value="Population" label="Population" />
+        </RadioGroup>
+        {/* only displays autocomplete component if radio value is Patient */}
+        {radioValue === "Subject" ? (
+          <SelectComponent resourceType="Patient" setValue={setPatientValue} value={patientValue} />
+        ) : null}
         <SelectComponent
           resourceType="Practitioner"
           setValue={setPractitionerValue}

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -46,7 +46,7 @@ const EvaluateMeasurePage = () => {
         <RadioGroup
           value={radioValue}
           onChange={setRadioValue}
-          label="Select Subject or Population"
+          label="Select a reportType"
           required
         >
           <Radio value="Subject" label="Subject" />


### PR DESCRIPTION
## Summary
Adds a radioGroup to the Evaluate Measure page with two radio options, subject and population. If the user selects the subject option, an autocomplete component is rendered on the page. If the user selects the population option, no new components are rendered. 
## New behavior
On the Evaluate Measure page for a valid measure, a radioGroup is now rendered, allowing the user to choose either subject or population. An autocomplete component is conditionally rendered if the user selects the subject radio button, otherwise there are no changes.  
## Code changes
- **pages/[resource]/[id]/SelectComponent**  adds a state variable to keep track of autocomplete value changes
- **pages/[resource]/[id]/evaluate.tsx**  renders radioGroup
- **__tests__/pages/resource/id/evaluate.test.tsx**, unit tests added to file
- - **__tests__/pages/resource/id/SelectComponent.test.tsx**, unit tests added to file

## Testing Guidance
See the README.md for first time setup instructions.
#### Testing in browser: 
- To start the frontend: `npm run dev` then navigate to http://localhost:3001 in a browser
- Click on “Measure” from the left-hand-side navigation menu. Click on any of the IDs. Click on the “Evaluate Measure” button near the top right of the main page body.
- To test the subject radio button
  - Click the subject option. A Patient autocomplete component should appear.
- To test the population button
  - Click the population option. No Patient autocomplete component should appear. If there was one previously, it should disappear. Note that the Practitioner autocomplete component is unrelated and should not change regardless of which option is selected. 
#### Unit testing: 
- Run the unit tests: `npm run test`