### PR TITLE
Evaluate measure request preview

### DIFF
--- a/__tests__/components/MeasureDatePickers.test.tsx
+++ b/__tests__/components/MeasureDatePickers.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen, act, within } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import {
+  mantineRecoilWrap,
+  createMockRouter,
+  getMockFetchImplementation,
+  getMockFetchImplementationError,
+} from "../helpers/testHelpers";
+import { RouterContext } from "next/dist/shared/lib/router-context";
+import EvaluateMeasurePage from "../../pages/[resourceType]/[id]/evaluate";
+import { DateTime } from "luxon";
+import MeasureDatePickers from "../../components/MeasureDatePickers";
+
+const MEASURE_BODY_NO_DATES = {
+  resourceType: "Measure",
+  id: "measure-EXM104-8.4.000",
+  meta: {
+    lastUpdated: "2022-07-21T18:12:25.008Z",
+  },
+  effectivePeriod: {},
+};
+
+const MEASURE_BODY_NO_EFFECTIVE_PERIOD = {
+  resourceType: "Measure",
+  id: "measure-EXM104-8.4.000",
+  meta: {
+    lastUpdated: "2022-07-21T18:12:25.008Z",
+  },
+};
+
+const ERROR_400_RESPONSE_BODY = { issue: [{ details: { text: "Invalid resource ID" } }] };
+describe("Test evaluate page render for measure without dates in effective period", () => {
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementation(MEASURE_BODY_NO_DATES);
+  });
+  it("should display DatePickers with default dates", async () => {
+    await act(async () => {
+      render(
+        <MeasureDatePickers
+          measureID="measure-EXM104-8.2.000"
+          periodStart={new Date(`${DateTime.now().year}-01-01T00:00:00`)}
+          periodEnd={new Date(`${DateTime.now().year}-12-31T00:00:00`)}
+          startOnUpdate={jest.fn()}
+          endOnUpdate={jest.fn()}
+        />,
+      );
+    });
+    expect(await screen.findByDisplayValue("January 1, 2022")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("December 31, 2022")).toBeInTheDocument();
+  });
+});
+
+describe("Test evaluate page render for measure without effective period", () => {
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementation(MEASURE_BODY_NO_EFFECTIVE_PERIOD);
+  });
+  it("should display DatePickers with default dates", async () => {
+    await act(async () => {
+      render(
+        <MeasureDatePickers
+          measureID="measure-EXM104-8.2.000"
+          periodStart={new Date(`${DateTime.now().year}-01-01T00:00:00`)}
+          periodEnd={new Date(`${DateTime.now().year}-12-31T00:00:00`)}
+          startOnUpdate={jest.fn()}
+          endOnUpdate={jest.fn()}
+        />,
+      );
+    });
+    expect(await screen.findByDisplayValue("January 1, 2022")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("December 31, 2022")).toBeInTheDocument();
+  });
+});
+
+describe("non 20x response in evaluate measure page", () => {
+  beforeEach(() => {
+    global.fetch = getMockFetchImplementation(ERROR_400_RESPONSE_BODY, 400, "BadRequest");
+  });
+  it("error notification should appear with expected messages", async () => {
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <RouterContext.Provider
+            value={createMockRouter({
+              query: { resourceType: "Measure", id: "measure-EXM104-8.4.000" },
+            })}
+          >
+            <EvaluateMeasurePage />
+          </RouterContext.Provider>,
+        ),
+      );
+    });
+    const errorNotif = (await screen.findByRole("alert")) as HTMLDivElement;
+    expect(errorNotif).toBeInTheDocument();
+    expect(within(errorNotif).getByText(/400 BadRequest/)).toBeInTheDocument();
+    expect(within(errorNotif).getByText(/Invalid resource ID/)).toBeInTheDocument();
+  });
+});
+
+describe("Evaluate measure page fetch throws error", () => {
+  beforeEach(() => {
+    global.fetch = getMockFetchImplementationError("Problem connecting to server");
+  });
+  it("Server error notification should appear with expected messages", async () => {
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <RouterContext.Provider
+            value={createMockRouter({
+              query: { resourceType: "Measure", id: "measure-EXM104-8.4.000" },
+            })}
+          >
+            <EvaluateMeasurePage />
+          </RouterContext.Provider>,
+        ),
+      );
+    });
+    const errorNotif = (await screen.findByRole("alert")) as HTMLDivElement;
+    expect(errorNotif).toBeInTheDocument();
+    expect(within(errorNotif).getByText(/Not connected to server!/)).toBeInTheDocument();
+    expect(screen.getByText("Something went wrong.")).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/SelectComponent.test.tsx
+++ b/__tests__/components/SelectComponent.test.tsx
@@ -98,12 +98,10 @@ describe("Select component render", () => {
 
     //mocks user key clicks to test the input fields and drop down menus
     await act(async () => {
-      //fireEvent.change(input, { target: { value: "P" } });
+      fireEvent.change(input, { target: { value: "P" } });
       fireEvent.keyDown(autocomplete, { key: "ArrowDown" });
       fireEvent.keyDown(autocomplete, { key: "Enter" });
     });
-
-    screen.debug(undefined, 30000);
 
     //verifies that the drop down autocomplete menu is populated with the resource IDs fetched from the server
     const options = screen.getAllByRole("option");

--- a/__tests__/components/SelectComponent.test.tsx
+++ b/__tests__/components/SelectComponent.test.tsx
@@ -98,10 +98,12 @@ describe("Select component render", () => {
 
     //mocks user key clicks to test the input fields and drop down menus
     await act(async () => {
-      fireEvent.change(input, { target: { value: "P" } });
+      //fireEvent.change(input, { target: { value: "P" } });
       fireEvent.keyDown(autocomplete, { key: "ArrowDown" });
       fireEvent.keyDown(autocomplete, { key: "Enter" });
     });
+
+    screen.debug(undefined, 30000);
 
     //verifies that the drop down autocomplete menu is populated with the resource IDs fetched from the server
     const options = screen.getAllByRole("option");

--- a/__tests__/pages/resource/id/evaluate.test.tsx
+++ b/__tests__/pages/resource/id/evaluate.test.tsx
@@ -108,11 +108,11 @@ describe("Test evaluate page render for measure", () => {
     expect(screen.getByTestId("back-button")).toBeInTheDocument();
     expect(screen.getByText("Evaluate Measure: measure-EXM104-8.2.000")).toBeInTheDocument();
     expect(screen.getByText("Request Preview:")).toBeInTheDocument();
-
+    screen.debug(undefined, 30000);
     //Request preview should include the dates from the Measure's effective period
     expect(
-      screen.getByText(
-        "/Measure/measure-EXM104-8.2.000/$evaluate-measure?periodStart=2019-01-01T05:00:00.000Z&periodEnd=2019-12-31T05:00:00.000Z&reportType=subject",
+      await screen.findByText(
+        "/Measure/measure-EXM104-8.2.000/$evaluate-measure?periodStart=2019-01-01&periodEnd=2019-12-31&reportType=subject",
       ),
     ).toBeInTheDocument();
   });
@@ -163,8 +163,8 @@ describe("Test evaluate page render for measure", () => {
 
     //request preview should include the updated dates
     expect(
-      screen.getByText(
-        "/Measure/measure-EXM104-8.2.000/$evaluate-measure?periodStart=2018-02-02T05:00:00.000Z&periodEnd=2020-11-13T05:00:00.000Z&reportType=subject",
+      await screen.findByText(
+        "/Measure/measure-EXM104-8.2.000/$evaluate-measure?periodStart=2018-02-02&periodEnd=2020-11-13&reportType=subject",
       ),
     ).toBeInTheDocument();
   });
@@ -352,9 +352,10 @@ describe("Select component, Radio button, and request preview render", () => {
     await act(async () => {
       fireEvent.change(practitionerSelectComponent, { target: { value: "P" } });
     });
+    screen.debug(undefined, 30000);
     expect(
-      screen.getByText(
-        "/Measure/Measure-12/$evaluate-measure?periodStart=2022-01-01T05:00:00.000Z&periodEnd=2022-12-31T05:00:00.000Z&reportType=subject&subject=P&practitioner=P",
+      await screen.findByText(
+        "/Measure/Measure-12/$evaluate-measure?periodStart=2022-01-01&periodEnd=2022-12-31&reportType=subject&subject=P&practitioner=P",
       ),
     ).toBeInTheDocument();
   });
@@ -381,8 +382,8 @@ describe("Select component, Radio button, and request preview render", () => {
     expect(screen.findByText("Select Patient")).not.toBeInTheDocument;
     //expect the request preview to include reportType=population
     expect(
-      screen.getByText(
-        "/Measure/Measure-12/$evaluate-measure?periodStart=2022-01-01T05:00:00.000Z&periodEnd=2022-12-31T05:00:00.000Z&reportType=population",
+      await screen.findByText(
+        "/Measure/Measure-12/$evaluate-measure?periodStart=2022-01-01&periodEnd=2022-12-31&reportType=population",
       ),
     ).toBeInTheDocument();
   });

--- a/__tests__/pages/resource/id/evaluate.test.tsx
+++ b/__tests__/pages/resource/id/evaluate.test.tsx
@@ -108,10 +108,9 @@ describe("Test evaluate page render for measure", () => {
     expect(screen.getByTestId("back-button")).toBeInTheDocument();
     expect(screen.getByText("Evaluate Measure: measure-EXM104-8.2.000")).toBeInTheDocument();
     expect(screen.getByText("Request Preview:")).toBeInTheDocument();
-    screen.debug(undefined, 30000);
     //Request preview should include the dates from the Measure's effective period
     expect(
-      await screen.findByText(
+      screen.getByText(
         "/Measure/measure-EXM104-8.2.000/$evaluate-measure?periodStart=2019-01-01&periodEnd=2019-12-31&reportType=subject",
       ),
     ).toBeInTheDocument();
@@ -163,7 +162,7 @@ describe("Test evaluate page render for measure", () => {
 
     //request preview should include the updated dates
     expect(
-      await screen.findByText(
+      screen.getByText(
         "/Measure/measure-EXM104-8.2.000/$evaluate-measure?periodStart=2018-02-02&periodEnd=2020-11-13&reportType=subject",
       ),
     ).toBeInTheDocument();
@@ -352,9 +351,8 @@ describe("Select component, Radio button, and request preview render", () => {
     await act(async () => {
       fireEvent.change(practitionerSelectComponent, { target: { value: "P" } });
     });
-    screen.debug(undefined, 30000);
     expect(
-      await screen.findByText(
+      screen.getByText(
         "/Measure/Measure-12/$evaluate-measure?periodStart=2022-01-01&periodEnd=2022-12-31&reportType=subject&subject=P&practitioner=P",
       ),
     ).toBeInTheDocument();
@@ -382,7 +380,7 @@ describe("Select component, Radio button, and request preview render", () => {
     expect(screen.findByText("Select Patient")).not.toBeInTheDocument;
     //expect the request preview to include reportType=population
     expect(
-      await screen.findByText(
+      screen.getByText(
         "/Measure/Measure-12/$evaluate-measure?periodStart=2022-01-01&periodEnd=2022-12-31&reportType=population",
       ),
     ).toBeInTheDocument();

--- a/__tests__/pages/resource/id/evaluate.test.tsx
+++ b/__tests__/pages/resource/id/evaluate.test.tsx
@@ -94,7 +94,7 @@ describe("Test evaluate page render for measure", () => {
     global.fetch = getMockFetchImplementation(MEASURE_BODY_WITH_DATES);
   });
 
-  it("should display back button and expected title", async () => {
+  it("should display back button, expected title, and request preview", async () => {
     await act(async () => {
       render(
         <RouterContext.Provider
@@ -108,6 +108,14 @@ describe("Test evaluate page render for measure", () => {
     });
     expect(screen.getByTestId("back-button")).toBeInTheDocument();
     expect(screen.getByText("Evaluate Measure: measure-EXM104-8.2.000")).toBeInTheDocument();
+    expect(screen.getByText("Request Preview:")).toBeInTheDocument();
+
+    //Request preview should include the dates from the Measure's effective period
+    expect(
+      screen.getByText(
+        "/Measure/measure-EXM104-8.2.000/$evaluate-measure?periodStart=2019-01-01T05:00:00.000Z&periodEnd=2019-12-31T05:00:00.000Z",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("should display two DatePickers pre-filled with expected dates", async () => {
@@ -127,7 +135,7 @@ describe("Test evaluate page render for measure", () => {
     expect(screen.getByDisplayValue("December 31, 2019")).toBeInTheDocument();
   });
 
-  it("DatePickers display value should changed when value is updated", async () => {
+  it("DatePickers and request preview display value should changed when dates are updated", async () => {
     await act(async () => {
       render(
         <RouterContext.Provider
@@ -153,75 +161,14 @@ describe("Test evaluate page render for measure", () => {
     });
     expect(screen.getByDisplayValue("February 2, 2018")).toBeInTheDocument();
     expect(screen.getByDisplayValue("November 13, 2020")).toBeInTheDocument();
-  });
-});
 
-describe("Test evaluate page render for measure", () => {
-  beforeAll(() => {
-    global.fetch = getMockFetchImplementation(RESOURCE_ID_BODY);
-  });
-  it("should display expected text", async () => {
-    await act(async () => {
-      render(
-        <RouterContext.Provider
-          value={createMockRouter({
-            query: { resourceType: "Measure", id: "measure-EXM104-8.4.000" },
-          })}
-        >
-          <EvaluateMeasurePage />
-        </RouterContext.Provider>,
-      );
-    });
-    expect(await screen.findByDisplayValue("January 1, 2022")).toBeInTheDocument();
-    expect(screen.getByDisplayValue("December 31, 2022")).toBeInTheDocument();
-  });
-});
-
-describe("Test evaluate page render for measure without effective period", () => {
-  beforeAll(() => {
-    global.fetch = getMockFetchImplementation(MEASURE_BODY_NO_EFFECTIVE_PERIOD);
-  });
-
-  it("should display DatePickers with default dates", async () => {
-    await act(async () => {
-      render(
-        <RouterContext.Provider
-          value={createMockRouter({
-            query: { resourceType: "Measure", id: "measure-EXM104-8.4.000" },
-          })}
-        >
-          <EvaluateMeasurePage />
-        </RouterContext.Provider>,
-      );
-    });
-    expect(await screen.findByDisplayValue("January 1, 2022")).toBeInTheDocument();
-    expect(screen.getByDisplayValue("December 31, 2022")).toBeInTheDocument();
-  });
-});
-
-describe("Test evaluate page render for non-measure", () => {
-  beforeAll(() => {
-    global.fetch = getMockFetchImplementation(RESOURCE_ID_BODY);
-  });
-  it("should display an error message", async () => {
-    await act(async () => {
-      render(
-        <RouterContext.Provider
-          value={createMockRouter({
-            query: { resourceType: "DiagnosticReport", id: "denom-EXM125-3" },
-          })}
-        >
-          <EvaluateMeasurePage />
-        </RouterContext.Provider>,
-      );
-    });
-
-    expect(screen.getByTestId("back-button")).toBeInTheDocument();
     expect(
       screen.getByText(
-        /Cannot evaluate on resourceType: DiagnosticReport, only on resourceType: Measure/,
+        "/Measure/measure-EXM104-8.2.000/$evaluate-measure?periodStart=2018-02-02T05:00:00.000Z&periodEnd=2020-11-13T05:00:00.000Z",
       ),
     ).toBeInTheDocument();
+
+    //screen.debug(undefined, 30000);
   });
 });
 
@@ -266,6 +213,29 @@ describe("Test evaluate page render for measure without effective period", () =>
     });
     expect(await screen.findByDisplayValue("January 1, 2022")).toBeInTheDocument();
     expect(screen.getByDisplayValue("December 31, 2022")).toBeInTheDocument();
+  });
+});
+
+describe("Test evaluate page render for non-measure", () => {
+  it("should display an error message", async () => {
+    await act(async () => {
+      render(
+        <RouterContext.Provider
+          value={createMockRouter({
+            query: { resourceType: "DiagnosticReport", id: "denom-EXM125-3" },
+          })}
+        >
+          <EvaluateMeasurePage />
+        </RouterContext.Provider>,
+      );
+    });
+
+    expect(screen.getByTestId("back-button")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Cannot evaluate on resourceType: DiagnosticReport, only on resourceType: Measure/,
+      ),
+    ).toBeInTheDocument();
   });
 });
 
@@ -335,12 +305,17 @@ describe("Select component no practitioners", () => {
   it("should display no practioners", async () => {
     await act(async () => {
       render(
-        mantineRecoilWrap(
-          <SelectComponent resourceType="Practitioner" value="" setValue={jest.fn()} />,
-        ),
+        <RouterContext.Provider
+          value={createMockRouter({
+            query: { resourceType: "Measure", id: "Measure-12" },
+          })}
+        >
+          <EvaluateMeasurePage />
+        </RouterContext.Provider>,
       );
     });
   });
+
   expect(screen.findByText("No resources of type Practitioner found")).toBeInTheDocument;
 });
 
@@ -352,9 +327,13 @@ describe("Select component render", () => {
   it("should display a dropdown menu populated with resource ID's when prompted by user key presses", async () => {
     await act(async () => {
       render(
-        mantineRecoilWrap(
-          <SelectComponent resourceType="Practitioner" value="" setValue={jest.fn()} />,
-        ),
+        <RouterContext.Provider
+          value={createMockRouter({
+            query: { resourceType: "Measure", id: "Measure-12" },
+          })}
+        >
+          <EvaluateMeasurePage />
+        </RouterContext.Provider>,
       );
     });
 
@@ -368,10 +347,11 @@ describe("Select component render", () => {
       fireEvent.keyDown(autocomplete, { key: "Enter" });
     });
 
-    //verifies that the drop down autocomplete menu is populated with the resource IDs fetched from the server
-    const options = screen.getAllByRole("option");
-    expect(options[0].textContent).toBe("Practitioner/denom-EXM125-3");
-    expect(options[1].textContent).toBe("Practitioner/numer-EXM125-3");
+    expect(
+      screen.getByText(
+        "/Measure/Measure-12/$evaluate-measure?periodStart=2022-01-01T05:00:00.000Z&periodEnd=2022-12-31T05:00:00.000Z&practitioner=P",
+      ),
+    ).toBeInTheDocument();
   });
 });
 
@@ -396,6 +376,22 @@ describe("Radio button render subject", () => {
     const subjectRadio = screen.getByLabelText("Subject");
     expect(subjectRadio).toBeChecked();
     expect(screen.getByText("Select Patient")).toBeInTheDocument;
+
+    //expect(within(deleteModal).getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    //const autocomplete = screen.getByRole("combobox");
+    const input = screen.getByRole("searchbox", { name: "Select Patient" });
+    //autocomplete.focus();
+    //mocks user key clicks to test the input fields and drop down menus
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "P" } });
+    });
+
+    screen.debug(undefined, 30000);
+    expect(
+      screen.getByText(
+        "/Measure/Measure-12/$evaluate-measure?periodStart=2022-01-01T05:00:00.000Z&periodEnd=2022-12-31T05:00:00.000Z&reportType=subject&subject=Patient/P",
+      ),
+    ).toBeInTheDocument();
   });
 });
 
@@ -424,5 +420,11 @@ describe("Radio button render population", () => {
       fireEvent.click(populationRadio);
     });
     expect(screen.findByText("Select Patient")).not.toBeInTheDocument;
+    //expect the request preview to include reportType=population
+    expect(
+      screen.getByText(
+        "/Measure/Measure-12/$evaluate-measure?periodStart=2022-01-01T05:00:00.000Z&periodEnd=2022-12-31T05:00:00.000Z&reportType=population",
+      ),
+    ).toBeInTheDocument();
   });
 });

--- a/__tests__/pages/resource/id/evaluate.test.tsx
+++ b/__tests__/pages/resource/id/evaluate.test.tsx
@@ -112,7 +112,7 @@ describe("Test evaluate page render for measure", () => {
     //Request preview should include the dates from the Measure's effective period
     expect(
       screen.getByText(
-        "/Measure/measure-EXM104-8.2.000/$evaluate-measure?periodStart=2019-01-01T05:00:00.000Z&periodEnd=2019-12-31T05:00:00.000Z",
+        "/Measure/measure-EXM104-8.2.000/$evaluate-measure?periodStart=2019-01-01T05:00:00.000Z&periodEnd=2019-12-31T05:00:00.000Z&reportType=subject",
       ),
     ).toBeInTheDocument();
   });
@@ -164,7 +164,7 @@ describe("Test evaluate page render for measure", () => {
     //request preview should include the updated dates
     expect(
       screen.getByText(
-        "/Measure/measure-EXM104-8.2.000/$evaluate-measure?periodStart=2018-02-02T05:00:00.000Z&periodEnd=2020-11-13T05:00:00.000Z",
+        "/Measure/measure-EXM104-8.2.000/$evaluate-measure?periodStart=2018-02-02T05:00:00.000Z&periodEnd=2020-11-13T05:00:00.000Z&reportType=subject",
       ),
     ).toBeInTheDocument();
   });

--- a/components/MeasureDatePickers.tsx
+++ b/components/MeasureDatePickers.tsx
@@ -94,19 +94,25 @@ const MeasureDatePickers = ({
 
   if (!fetchingError) {
     return (
-      <Grid gutter="lg" min-width="15px" style={{ margin: 10 }}>
-        <Grid.Col md={4} lg={3} xl={2}>
+      <Grid gutter="lg" min-width="15px">
+        <Grid.Col md={6} lg={6} xl={6}>
           <DatePicker
-            label={<Text>Period Start</Text>}
+            label={<Text size="lg">Period Start</Text>}
             icon={<Calendar size={16} color={"#40a5bf"} />}
+            variant="filled"
+            radius="xl"
+            size="lg"
             value={periodStart}
             onChange={(v) => startOnUpdate(v ? v : new Date())}
             allowFreeInput
           ></DatePicker>
         </Grid.Col>
-        <Grid.Col md={4} lg={3} xl={2}>
+        <Grid.Col md={6} lg={6} xl={6}>
           <DatePicker
-            label={<Text>Period End</Text>}
+            label={<Text size="lg">Period End</Text>}
+            variant="filled"
+            radius="xl"
+            size="lg"
             icon={<Calendar size={16} color={"#40a5bf"} />}
             value={periodEnd}
             onChange={(v) => endOnUpdate(v ? v : new Date())}

--- a/components/MeasureDatePickers.tsx
+++ b/components/MeasureDatePickers.tsx
@@ -6,6 +6,14 @@ import { cleanNotifications, showNotification } from "@mantine/notifications";
 import { DateTime } from "luxon";
 import { fhirJson } from "@fhir-typescript/r4-core";
 
+/**
+ * MeasureDatePickerProps specifies the props that a MeasureDatePickers component takes in.
+ * @measureID is optional, specifies the Measure ID to be used to fetch an effective period from to fill the DatePickers
+ * @periodStart should be a state variable for setting the periodStart in a page/component that renders a MeasureDatePickers
+ * @periodEnd should be a state variable for setting the periodEnd in a page/component that renders a MeasureDatePickers
+ * @startOnUpdate is a set state variable function that gets called when the periodStart DatePickers value is changed
+ * @endOnUpdate is a set state variable function that gets called when the periodEnd DatePickers value is changed
+ */
 export interface MeasureDatePickerProps {
   measureID?: string;
   periodStart: Date;

--- a/components/SelectComponent.tsx
+++ b/components/SelectComponent.tsx
@@ -84,7 +84,11 @@ function PopulateIDHelper({
         onChange={setValue}
         label={`Select ${resourceType}`}
         placeholder="Start typing to see options"
+        sx={{ color: "#ffffff" }}
         data={myArray}
+        variant="filled"
+        radius="xl"
+        size="lg"
         limit={10}
         required={required ? required : false}
       />

--- a/components/SelectComponent.tsx
+++ b/components/SelectComponent.tsx
@@ -14,6 +14,8 @@ export interface SelectComponentProps {
   value: string;
   jsonBody?: fhirJson.Bundle;
   required?: boolean;
+  placeholder?: string;
+  disabled?: boolean;
 }
 
 /**
@@ -25,6 +27,8 @@ export default function SelectComponent({
   setValue,
   value,
   required,
+  placeholder,
+  disabled,
 }: SelectComponentProps) {
   const [responseBody, setResponseBody] = useState<fhirJson.Bundle>();
   const [fetchingError, setFetchingError] = useState(false);
@@ -58,6 +62,8 @@ export default function SelectComponent({
       setValue={setValue}
       value={value}
       required={required}
+      placeholder={placeholder}
+      disabled={disabled}
     />
   ) : (
     <div>Problem connecting to server</div>
@@ -70,6 +76,8 @@ function PopulateIDHelper({
   value,
   jsonBody,
   required,
+  placeholder,
+  disabled,
 }: SelectComponentProps) {
   const entryArray = jsonBody?.entry;
 
@@ -83,14 +91,14 @@ function PopulateIDHelper({
         value={value}
         onChange={setValue}
         label={`Select ${resourceType}`}
-        placeholder="Start typing to see options"
-        sx={{ color: "#ffffff" }}
+        placeholder={placeholder ? placeholder : "Start typing to see options"}
         data={myArray}
         variant="filled"
         radius="xl"
         size="lg"
         limit={10}
         required={required ? required : false}
+        disabled={disabled ? disabled : false}
       />
     );
   } else {

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -154,7 +154,7 @@ const EvaluateMeasurePage = () => {
                   <Text
                     size="md"
                     style={{ color: textGray, textAlign: "left" }}
-                  >{`${createRequestPreview()}`}</Text>{" "}
+                  >{`${createRequestPreview()}`}</Text>
                 </div>
               </Grid.Col>
               <Grid.Col span={3} style={{ minHeight: 100, margin: 5 }}>
@@ -171,7 +171,6 @@ const EvaluateMeasurePage = () => {
                       textAlign: "center",
                     }}
                   >
-                    {" "}
                     Sample Submit Button
                   </Button>
                 </div>

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -1,4 +1,4 @@
-import { Center, Divider, RadioGroup, Radio, Text, MantineProvider } from "@mantine/core";
+import { Center, Divider, RadioGroup, Radio, Text, MantineProvider, Button } from "@mantine/core";
 import { useRouter } from "next/router";
 import React, { useState } from "react";
 import { DateTime } from "luxon";
@@ -54,6 +54,7 @@ const EvaluateMeasurePage = () => {
     return requestPreview;
   };
 
+  //only appears on the measure page
   if (resourceType === "Measure" && id) {
     //for resourceType Measure, evaluate measure components are rendered
     return (
@@ -66,65 +67,118 @@ const EvaluateMeasurePage = () => {
         </Center>
 
         <Divider my="md" />
+        <div>
+          <Grid columns={3} style={{ margin: 15 }}>
+            <MantineProvider
+              // changes hex values associated with each Mantine color name to improve UI
+              theme={{
+                colors: {
+                  gray: replaceBackground,
+                  blue: replaceOutline,
+                  red: replaceSecondRed,
+                },
+              }}
+            >
+              <Grid.Col span={3}>
+                <Grid.Col span={3} style={{ minHeight: 100, margin: 5 }}>
+                  <MeasureDatePickers
+                    measureID={id as string}
+                    periodStart={periodStart}
+                    periodEnd={periodEnd}
+                    startOnUpdate={setPeriodStart}
+                    endOnUpdate={setPeriodEnd}
+                  />
+                </Grid.Col>
+                <Grid.Col span={3} style={{ margin: 5 }}>
+                  <RadioGroup
+                    value={radioValue}
+                    onChange={setRadioValue}
+                    label={<Text size="lg">Select a reportType</Text>}
+                    style={{ marginBottom: "25px" }}
+                  >
+                    <Radio value="Subject" label="Subject" />
+                    <Radio value="Population" label="Population" />
+                  </RadioGroup>
 
-        <Grid columns={8} style={{ margin: 10 }}>
-          <MantineProvider
-            // changes hex values associated with each Mantine color name to improve UI
-            theme={{
-              colors: {
-                gray: replaceBackground,
-                blue: replaceOutline,
-                red: replaceSecondRed,
-              },
-            }}
-          >
-            <Grid.Col span={8} style={{ minHeight: 100 }}>
-              <MeasureDatePickers
-                measureID={id as string}
-                periodStart={periodStart}
-                periodEnd={periodEnd}
-                startOnUpdate={setPeriodStart}
-                endOnUpdate={setPeriodEnd}
-              />
-            </Grid.Col>
+                  {/* only displays autocomplete component if radio value is Patient */}
+                  {radioValue === "Subject" ? (
+                    <SelectComponent
+                      resourceType="Patient"
+                      setValue={setPatientValue}
+                      value={patientValue}
+                      required={true}
+                    />
+                  ) : (
+                    <SelectComponent
+                      resourceType="Patient"
+                      setValue={setPatientValue}
+                      value={patientValue}
+                      disabled={true}
+                      placeholder="Patient selection disabled when 'Population' is selected"
+                    />
+                  )}
+                </Grid.Col>
 
-            <Grid.Col span={4} style={{ minHeight: 100 }}>
-              <RadioGroup
-                value={radioValue}
-                onChange={setRadioValue}
-                label="Select a reportType"
-                required
-              >
-                <Radio value="Subject" label="Subject" />
-                <Radio value="Population" label="Population" />
-              </RadioGroup>
-              {/* only displays autocomplete component if radio value is Patient */}
-              {radioValue === "Subject" ? (
-                <SelectComponent
-                  resourceType="Patient"
-                  setValue={setPatientValue}
-                  value={patientValue}
-                  required={true}
-                />
-              ) : null}
-            </Grid.Col>
-
-            <Grid.Col span={4} style={{ minHeight: 100 }}>
-              <SelectComponent
-                resourceType="Practitioner"
-                setValue={setPractitionerValue}
-                value={practitionerValue}
-              />
-            </Grid.Col>
-
-            <Grid.Col span={8} style={{ minHeight: 100 }}>
-              <h3 style={{ color: textGray, marginTop: "20px", marginBottom: "2px" }}>
-                Request Preview:{" "}
-              </h3>
-              <Text size="md" style={{ color: textGray }}>{`${createRequestPreview()}`}</Text>{" "}
-            </Grid.Col>
-          </MantineProvider>
-        </Grid>
+                <Grid.Col span={3} style={{ margin: 5 }}>
+                  <SelectComponent
+                    resourceType="Practitioner"
+                    setValue={setPractitionerValue}
+                    value={practitionerValue}
+                  />
+                </Grid.Col>
+              </Grid.Col>
+              <Grid.Col span={3} style={{ margin: 5 }}>
+                <h3
+                  style={{
+                    color: textGray,
+                    marginTop: "20px",
+                    marginBottom: "2px",
+                    textAlign: "center",
+                  }}
+                >
+                  Request Preview:{" "}
+                </h3>
+                <div
+                  style={{
+                    textAlign: "center",
+                    overflowWrap: "break-word",
+                    padding: "10px",
+                    backgroundColor: "#F1F3F5",
+                    border: "1px solid",
+                    borderColor: "#4a4f4f",
+                    borderRadius: "20px",
+                    marginLeft: "30px",
+                    marginRight: "30px",
+                  }}
+                >
+                  <Text
+                    size="md"
+                    style={{ color: textGray, textAlign: "left" }}
+                  >{`${createRequestPreview()}`}</Text>{" "}
+                </div>
+              </Grid.Col>
+              <Grid.Col span={3} style={{ minHeight: 100, margin: 5 }}>
+                <div
+                  style={{
+                    textAlign: "center",
+                  }}
+                >
+                  <Button
+                    color="cyan"
+                    radius="lg"
+                    size="md"
+                    style={{
+                      textAlign: "center",
+                    }}
+                  >
+                    {" "}
+                    Sample Submit Button
+                  </Button>
+                </div>
+              </Grid.Col>
+            </MantineProvider>
+          </Grid>
+        </div>
       </>
     );
   } else {

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -1,4 +1,4 @@
-import { Center, Divider, RadioGroup, Radio, Text } from "@mantine/core";
+import { Center, Divider, RadioGroup, Radio, Text, MantineProvider } from "@mantine/core";
 import { useRouter } from "next/router";
 import React, { useState } from "react";
 import { DateTime } from "luxon";
@@ -6,6 +6,12 @@ import { textGray } from "../../../styles/appColors";
 import BackButton from "../../../components/BackButton";
 import SelectComponent from "../../../components/SelectComponent";
 import MeasureDatePickers from "../../../components/MeasureDatePickers";
+import { Grid } from "@mantine/core";
+import {
+  replaceBackground,
+  replaceOutline,
+  replaceSecondRed,
+} from "../../../styles/codeColorScheme";
 
 const DEFAULT_PERIOD_START = new Date(`${DateTime.now().year}-01-01T00:00:00`);
 const DEFAULT_PERIOD_END = new Date(`${DateTime.now().year}-12-31T00:00:00`);
@@ -55,44 +61,67 @@ const EvaluateMeasurePage = () => {
             Evaluate Measure: {id}
           </h2>
         </Center>
+
         <Divider my="md" />
-        <MeasureDatePickers
-          measureID={id as string}
-          periodStart={periodStart}
-          periodEnd={periodEnd}
-          startOnUpdate={setPeriodStart}
-          endOnUpdate={setPeriodEnd}
-        />
-        <RadioGroup
-          value={radioValue}
-          onChange={setRadioValue}
-          label="Select a reportType"
-          required
-        >
-          <Radio value="Subject" label="Subject" />
-          <Radio value="Population" label="Population" />
-        </RadioGroup>
-        {/* only displays autocomplete component if radio value is Patient */}
-        {radioValue === "Subject" ? (
-          <SelectComponent
-            resourceType="Patient"
-            setValue={setPatientValue}
-            value={patientValue}
-            required={true}
-          />
-        ) : null}
-        <SelectComponent
-          resourceType="Practitioner"
-          setValue={setPractitionerValue}
-          value={practitionerValue}
-        />
-        <h3 style={{ color: textGray, marginTop: "20px", marginBottom: "2px" }}>
-          Request Preview:{" "}
-        </h3>
-        <Text
-          size="md"
-          style={{ backgroundColor: "#e3fafc", color: textGray }}
-        >{`${createRequestPreview()}`}</Text>
+
+        <Grid columns={8} style={{ margin: 10 }}>
+          <MantineProvider
+            // changes hex values associated with each Mantine color name to improve UI
+            theme={{
+              colors: {
+                gray: replaceBackground,
+                blue: replaceOutline,
+                red: replaceSecondRed,
+              },
+            }}
+          >
+            <Grid.Col span={8} style={{ minHeight: 100 }}>
+              <MeasureDatePickers
+                measureID={id as string}
+                periodStart={periodStart}
+                periodEnd={periodEnd}
+                startOnUpdate={setPeriodStart}
+                endOnUpdate={setPeriodEnd}
+              />
+            </Grid.Col>
+
+            <Grid.Col span={4} style={{ minHeight: 100 }}>
+              <RadioGroup
+                value={radioValue}
+                onChange={setRadioValue}
+                label="Select a reportType"
+                required
+              >
+                <Radio value="Subject" label="Subject" />
+                <Radio value="Population" label="Population" />
+              </RadioGroup>
+              {/* only displays autocomplete component if radio value is Patient */}
+              {radioValue === "Subject" ? (
+                <SelectComponent
+                  resourceType="Patient"
+                  setValue={setPatientValue}
+                  value={patientValue}
+                  required={true}
+                />
+              ) : null}
+            </Grid.Col>
+
+            <Grid.Col span={4} style={{ minHeight: 100 }}>
+              <SelectComponent
+                resourceType="Practitioner"
+                setValue={setPractitionerValue}
+                value={practitionerValue}
+              />
+            </Grid.Col>
+
+            <Grid.Col span={8} style={{ minHeight: 100 }}>
+              <h3 style={{ color: textGray, marginTop: "20px", marginBottom: "2px" }}>
+                Request Preview:{" "}
+              </h3>
+              <Text size="md" style={{ color: textGray }}>{`${createRequestPreview()}`}</Text>{" "}
+            </Grid.Col>
+          </MantineProvider>
+        </Grid>
       </>
     );
   } else {

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -11,10 +11,12 @@ const DEFAULT_PERIOD_START = new Date(`${DateTime.now().year}-01-01T00:00:00`);
 const DEFAULT_PERIOD_END = new Date(`${DateTime.now().year}-12-31T00:00:00`);
 
 /**
- * EvaluateMeasurePage is a page that renders a back button and DatePickers that are pre-filled with
- * a Measure's effective period dates or default dates.
+ * EvaluateMeasurePage is a page that renders a back button pre-filled DatePickers, radio buttons,
+ * auto-complete boxes, and a text preview of the measure request.
+ * The DatePickers are pre-filled with a Measure's effective period dates or default dates.
+ * The Patient SelectComponent only appears if the reportType selected is "Subject".
  * If the url resourceType is not a Measure, an error message is displayed.
- * @returns React node with a back button and MeasureDatePickers if on a valid Measure url
+ * @returns React node with a back button, MeasureDatePickers, SelectComponents, and a RadioGroup if on a valid Measure url
  */
 const EvaluateMeasurePage = () => {
   const router = useRouter();

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -1,4 +1,4 @@
-import { Center, Divider, RadioGroup, Radio } from "@mantine/core";
+import { Center, Divider, RadioGroup, Radio, Text } from "@mantine/core";
 import { useRouter } from "next/router";
 import React, { useState } from "react";
 import { DateTime } from "luxon";
@@ -24,6 +24,20 @@ const EvaluateMeasurePage = () => {
   const [patientValue, setPatientValue] = useState("");
   const [periodStart, setPeriodStart] = useState<Date>(DEFAULT_PERIOD_START);
   const [periodEnd, setPeriodEnd] = useState<Date>(DEFAULT_PERIOD_END);
+
+  const createRequestPreview = () => {
+    let requestPreview = `/Measure/${id}/$evaluate-measure?periodStart=${periodStart.toJSON()}&periodEnd=${periodEnd.toISOString()}`;
+    if (radioValue) {
+      requestPreview += `&reportType=${radioValue.toLowerCase()}`;
+      if (radioValue.toLowerCase() === "subject" && patientValue) {
+        requestPreview += `&subject=Patient/${patientValue}`;
+      }
+    }
+    if (practitionerValue) {
+      requestPreview += `&practitioner=${practitionerValue}`;
+    }
+    return requestPreview;
+  };
 
   if (resourceType === "Measure" && id) {
     //for resourceType Measure, evaluate measure components are rendered
@@ -66,6 +80,13 @@ const EvaluateMeasurePage = () => {
           setValue={setPractitionerValue}
           value={practitionerValue}
         />
+        <h3 style={{ color: textGray, marginTop: "20px", marginBottom: "2px" }}>
+          Request Preview:{" "}
+        </h3>
+        <Text
+          size="md"
+          style={{ backgroundColor: "#e3fafc", color: textGray }}
+        >{`${createRequestPreview()}`}</Text>
       </>
     );
   } else {

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -16,7 +16,7 @@ const DEFAULT_PERIOD_END = new Date(`${DateTime.now().year}-12-31T00:00:00`);
  * The DatePickers are pre-filled with a Measure's effective period dates or default dates.
  * The Patient SelectComponent only appears if the reportType selected is "Subject".
  * If the url resourceType is not a Measure, an error message is displayed.
- * @returns React node with a back button, MeasureDatePickers, SelectComponents, and a RadioGroup if on a valid Measure url
+ * @returns React node with a back button, MeasureDatePickers, SelectComponents, a RadioGroup, and Text for the request preview
  */
 const EvaluateMeasurePage = () => {
   const router = useRouter();
@@ -27,12 +27,16 @@ const EvaluateMeasurePage = () => {
   const [periodStart, setPeriodStart] = useState<Date>(DEFAULT_PERIOD_START);
   const [periodEnd, setPeriodEnd] = useState<Date>(DEFAULT_PERIOD_END);
 
+  /**
+   * createRequestPreview builds the request preview with the evaluate measure state variables
+   * @returns the request preview as a string
+   */
   const createRequestPreview = () => {
     let requestPreview = `/Measure/${id}/$evaluate-measure?periodStart=${periodStart.toJSON()}&periodEnd=${periodEnd.toISOString()}`;
     if (radioValue) {
       requestPreview += `&reportType=${radioValue.toLowerCase()}`;
       if (radioValue.toLowerCase() === "subject" && patientValue) {
-        requestPreview += `&subject=Patient/${patientValue}`;
+        requestPreview += `&subject=${patientValue}`;
       }
     }
     if (practitionerValue) {

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -38,7 +38,10 @@ const EvaluateMeasurePage = () => {
    * @returns the request preview as a string
    */
   const createRequestPreview = () => {
-    let requestPreview = `/Measure/${id}/$evaluate-measure?periodStart=${periodStart.toJSON()}&periodEnd=${periodEnd.toISOString()}`;
+    //dates are formatted to be in the form "YYYY-MM-DD", with no timezone info
+    let requestPreview = `/Measure/${id}/$evaluate-measure?periodStart=${DateTime.fromISO(
+      periodStart.toISOString(),
+    ).toISODate()}&periodEnd=${DateTime.fromISO(periodEnd.toISOString()).toISODate()}`;
     if (radioValue) {
       requestPreview += `&reportType=${radioValue.toLowerCase()}`;
       if (radioValue.toLowerCase() === "subject" && patientValue) {

--- a/pages/[resourceType]/[id]/index.tsx
+++ b/pages/[resourceType]/[id]/index.tsx
@@ -140,7 +140,7 @@ function ResourceIDPage() {
               language="json"
               data-testid="prism-page-content"
               colorScheme="dark"
-              style={{ maxWidth: "77vw", height: "80vh", backgroundColor: "#FFFFFF" }}
+              style={{ maxWidth: "78vw", height: "80vh", backgroundColor: "#FFFFFF" }}
             >
               {pageBody}
             </Prism>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -39,7 +39,7 @@ export default function App(props: AppProps) {
             <AppShell
               padding="md"
               navbar={
-                <Navbar width={{ base: 320 }} height="90vh" p="xs">
+                <Navbar width={{ base: "18vw" }} height="90vh" p="xs">
                   <Navbar.Section>
                     <Box
                       sx={(theme) => ({

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -35,6 +35,7 @@ export default function App(props: AppProps) {
         }}
       >
         <NotificationsProvider position="top-center">
+<<<<<<< HEAD
           <CountProvider>
             <AppShell
               padding="md"
@@ -82,6 +83,53 @@ export default function App(props: AppProps) {
               <Component {...pageProps} />
             </AppShell>
           </CountProvider>
+=======
+          <AppShell
+            padding="md"
+            navbar={
+              <Navbar width={{ base: 320 }} height="90vh" p="xs">
+                <Navbar.Section>
+                  <Box
+                    sx={(theme) => ({
+                      backgroundColor: "white",
+                      textAlign: "center",
+                      paddingTop: "8px",
+                      paddingBottom: "12px",
+                      borderRadius: theme.radius.xs,
+                      cursor: "pointer",
+                    })}
+                  >
+                    <Text size="xl" weight={700} color={textGray}>
+                      Resources
+                    </Text>
+                  </Box>
+                </Navbar.Section>
+                <Divider my="sm" style={{ paddingBottom: "15px" }} />
+                <Navbar.Section grow component={ScrollArea} mt="-xs" mb="-xs" ml="-xl" mr="-xs">
+                  <ResourceCounts />
+                </Navbar.Section>
+              </Navbar>
+            }
+            header={
+              <Header height={80} style={{ backgroundColor: "#BDEBF0", color: textGray }}>
+                <Center>
+                  <Link href={"/"}>
+                    <h1 style={{ marginTop: "12px", cursor: "pointer" }}>
+                      DEQM Test Server Frontend
+                    </h1>
+                  </Link>
+                </Center>
+              </Header>
+            }
+            styles={(theme) => ({
+              main: {
+                backgroundColor: theme.colors.gray[0],
+              },
+            })}
+          >
+            <Component {...pageProps} />
+          </AppShell>
+>>>>>>> b2a0bbbb (UI updates)
         </NotificationsProvider>
       </MantineProvider>
     </>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -63,7 +63,7 @@ export default function App(props: AppProps) {
                 </Navbar>
               }
               header={
-                <Header height={80} style={{ backgroundColor: "#D0F1F4", color: textGray }}>
+                <Header height={80} style={{ backgroundColor: "#bdebf0", color: textGray }}>
                   <Center>
                     <Link href={"/"}>
                       <h1 style={{ marginTop: "12px", cursor: "pointer" }}>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -35,7 +35,6 @@ export default function App(props: AppProps) {
         }}
       >
         <NotificationsProvider position="top-center">
-<<<<<<< HEAD
           <CountProvider>
             <AppShell
               padding="md"
@@ -83,53 +82,6 @@ export default function App(props: AppProps) {
               <Component {...pageProps} />
             </AppShell>
           </CountProvider>
-=======
-          <AppShell
-            padding="md"
-            navbar={
-              <Navbar width={{ base: 320 }} height="90vh" p="xs">
-                <Navbar.Section>
-                  <Box
-                    sx={(theme) => ({
-                      backgroundColor: "white",
-                      textAlign: "center",
-                      paddingTop: "8px",
-                      paddingBottom: "12px",
-                      borderRadius: theme.radius.xs,
-                      cursor: "pointer",
-                    })}
-                  >
-                    <Text size="xl" weight={700} color={textGray}>
-                      Resources
-                    </Text>
-                  </Box>
-                </Navbar.Section>
-                <Divider my="sm" style={{ paddingBottom: "15px" }} />
-                <Navbar.Section grow component={ScrollArea} mt="-xs" mb="-xs" ml="-xl" mr="-xs">
-                  <ResourceCounts />
-                </Navbar.Section>
-              </Navbar>
-            }
-            header={
-              <Header height={80} style={{ backgroundColor: "#BDEBF0", color: textGray }}>
-                <Center>
-                  <Link href={"/"}>
-                    <h1 style={{ marginTop: "12px", cursor: "pointer" }}>
-                      DEQM Test Server Frontend
-                    </h1>
-                  </Link>
-                </Center>
-              </Header>
-            }
-            styles={(theme) => ({
-              main: {
-                backgroundColor: theme.colors.gray[0],
-              },
-            })}
-          >
-            <Component {...pageProps} />
-          </AppShell>
->>>>>>> b2a0bbbb (UI updates)
         </NotificationsProvider>
       </MantineProvider>
     </>

--- a/styles/codeColorScheme.tsx
+++ b/styles/codeColorScheme.tsx
@@ -77,3 +77,42 @@ export const replaceDelete: stringArray = [
   "#A61E4D",
   "#A61E4D",
 ];
+
+export const replaceBackground: stringArray = [
+  "#868E96",
+  "#F1F3F5",
+  "#4a4f4f",
+  "#4a4f4f;",
+  "#4a4f4f",
+  "#4a4f4f",
+  "#4a4f4f",
+  "#4a4f4f",
+  "#4a4f4f",
+  "#4a4f4f",
+];
+
+export const replaceOutline: stringArray = [
+  "#E3FAFC",
+  "#C5F6FA",
+  "#99E9F2",
+  "#66D9E8;",
+  "#3BC9DB",
+  "#22B8CF",
+  "#15AABF",
+  "#1098AD",
+  "#0C8599",
+  "#0B7285",
+];
+
+export const replaceSecondRed: stringArray = [
+  "#EB5262",
+  "#EB5262",
+  "#EB5262",
+  "#EB5262;",
+  "#EB5262",
+  "#EB5262",
+  "#EB5262",
+  "#EB5262",
+  "#EB5262",
+  "#EB5262",
+];


### PR DESCRIPTION
## Summary
Rendering of the evaluate measure request preview. 
## New behavior
On the Evaluate Measure page for a valid Measure, a preview of the evaluate measure request is displayed under the DatePickers, Radio buttons, and auto-complete components. As the user selects dates, the reportType, Practitioner, and Patient (if applicable), the request preview changes to reflect the current selections.
## Code changes
- **pages/[resource]/[id]/evaluate.tsx**  renders request preview 
- **__tests__/pages/resource/id/evaluate.test.tsx**, unit tests added to file, some unit tests altered, some removed and added to MeasureDatePickers.test filed
- **__tests__/components/MeasureDatePickers.test.tsx**, added file and tests
- **components/MeasureDatePickers.tsx**, comment added
## Testing Guidance
- See the README.md for first time setup instructions.
#### Testing in browser: 
To start the frontend: `npm run dev` then navigate to http://localhost:3001 in a browser
- Click on “Measure” from the left-hand-side navigation menu. Click on any of the IDs. Click on the “Evaluate Measure” button near the top right of the main page body.
- Change the values of the DatePickers, Radio buttons, and AutoComplete components and see the "Request Preview" change to accurately reflect the current values of those components.
#### Unit testing: 
- Run the unit tests: `npm run test`