### PR TITLE
Calculate evaluate measure

### DIFF
--- a/__tests__/pages/resource/id/evaluate.test.tsx
+++ b/__tests__/pages/resource/id/evaluate.test.tsx
@@ -93,7 +93,7 @@ describe("Test evaluate page render for measure", () => {
     global.fetch = getMockFetchImplementation(MEASURE_BODY_WITH_DATES);
   });
 
-  it("should display back button, expected title, and request preview", async () => {
+  it("should display back button, expected title, request preview, and disabled calculate button", async () => {
     await act(async () => {
       render(
         <RouterContext.Provider
@@ -108,6 +108,11 @@ describe("Test evaluate page render for measure", () => {
     expect(screen.getByTestId("back-button")).toBeInTheDocument();
     expect(screen.getByText("Evaluate Measure: measure-EXM104-8.2.000")).toBeInTheDocument();
     expect(screen.getByText("Request Preview:")).toBeInTheDocument();
+
+    const calculateButton = screen.getByRole("button", { name: "Calculate" }) as HTMLButtonElement;
+    expect(calculateButton).toBeInTheDocument();
+    expect(calculateButton).toBeDisabled();
+
     //Request preview should include the dates from the Measure's effective period
     expect(
       screen.getByText(
@@ -236,62 +241,6 @@ describe("Test evaluate page render for non-measure", () => {
   });
 });
 
-describe("non 20x response in evaluate measure page", () => {
-  beforeEach(() => {
-    global.fetch = getMockFetchImplementation(ERROR_400_RESPONSE_BODY, 400, "BadRequest");
-  });
-
-  it("error notification should appear with expected messages", async () => {
-    await act(async () => {
-      render(
-        mantineRecoilWrap(
-          <RouterContext.Provider
-            value={createMockRouter({
-              query: { resourceType: "Measure", id: "measure-EXM104-8.4.000" },
-            })}
-          >
-            <EvaluateMeasurePage />
-          </RouterContext.Provider>,
-        ),
-      );
-    });
-
-    const errorNotif = (await screen.findByRole("alert")) as HTMLDivElement;
-    expect(errorNotif).toBeInTheDocument();
-
-    expect(within(errorNotif).getByText(/400 BadRequest/)).toBeInTheDocument();
-    expect(within(errorNotif).getByText(/Invalid resource ID/)).toBeInTheDocument();
-  });
-});
-
-describe("Evaluate measure page fetch throws error", () => {
-  beforeEach(() => {
-    global.fetch = getMockFetchImplementationError("Problem connecting to server");
-  });
-
-  it("Server error notification should appear with expected messages", async () => {
-    await act(async () => {
-      render(
-        mantineRecoilWrap(
-          <RouterContext.Provider
-            value={createMockRouter({
-              query: { resourceType: "Measure", id: "measure-EXM104-8.4.000" },
-            })}
-          >
-            <EvaluateMeasurePage />
-          </RouterContext.Provider>,
-        ),
-      );
-    });
-
-    const errorNotif = (await screen.findByRole("alert")) as HTMLDivElement;
-    expect(errorNotif).toBeInTheDocument();
-
-    expect(within(errorNotif).getByText(/Not connected to server!/)).toBeInTheDocument();
-    expect(screen.getByText("Something went wrong.")).toBeInTheDocument();
-  });
-});
-
 describe("Select component no practitioners", () => {
   beforeAll(() => {
     global.fetch = getMockFetchImplementation(NO_RESOURCE_ID);
@@ -356,6 +305,10 @@ describe("Select component, Radio button, and request preview render", () => {
         "/Measure/Measure-12/$evaluate-measure?periodStart=2022-01-01&periodEnd=2022-12-31&reportType=subject&subject=P&practitioner=P",
       ),
     ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("button", { name: "Calculate" }) as HTMLButtonElement,
+    ).not.toBeDisabled();
   });
 
   it("tests for expected request preview and absence of Patient Select Component", async () => {
@@ -384,15 +337,19 @@ describe("Select component, Radio button, and request preview render", () => {
         "/Measure/Measure-12/$evaluate-measure?periodStart=2022-01-01&periodEnd=2022-12-31&reportType=population",
       ),
     ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("button", { name: "Calculate" }) as HTMLButtonElement,
+    ).not.toBeDisabled();
   });
 });
 
-describe.only("Error thrown during create test", () => {
+describe("Error thrown during create test", () => {
   beforeAll(() => {
-    global.fetch = getMockFetchImplementationError("400 Bad Request");
+    global.fetch = getMockFetchImplementation("400 Bad Request");
   });
 
-  it.only("Test for error notification when error is thrown", async () => {
+  it("Test for error notification when error is thrown", async () => {
     await act(async () => {
       render(
         mantineRecoilWrap(
@@ -421,5 +378,64 @@ describe.only("Error thrown during create test", () => {
     expect(within(errorNotif).getByText(/Problem connecting to server:/)).toBeInTheDocument();
     expect(within(errorNotif).getByText(/400 Bad Request/)).toBeInTheDocument();
     */
+  });
+});
+
+describe("non 20x response in evaluate measure page", () => {
+  beforeEach(() => {
+    global.fetch = getMockFetchImplementation(ERROR_400_RESPONSE_BODY, 400, "BadRequest");
+  });
+
+  it("error notification should appear with expected messages", async () => {
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <RouterContext.Provider
+            value={createMockRouter({
+              query: { resourceType: "Measure", id: "measure-EXM104-8.4.000" },
+            })}
+          >
+            <EvaluateMeasurePage />
+          </RouterContext.Provider>,
+        ),
+      );
+    });
+
+    const errorNotif = (await screen.findByRole("alert")) as HTMLDivElement;
+    expect(errorNotif).toBeInTheDocument();
+
+    expect(within(errorNotif).getByText(/400 BadRequest/)).toBeInTheDocument();
+    expect(within(errorNotif).getByText(/Invalid resource ID/)).toBeInTheDocument();
+    screen.debug(undefined, 30000);
+  });
+});
+
+describe("Evaluate measure page fetch throws error", () => {
+  beforeEach(() => {
+    global.fetch = getMockFetchImplementationError("Problem connecting to server");
+  });
+
+  it("Server error notification should appear with expected messages", async () => {
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <RouterContext.Provider
+            value={createMockRouter({
+              query: { resourceType: "Measure", id: "measure-EXM104-8.4.000" },
+            })}
+          >
+            <EvaluateMeasurePage />
+          </RouterContext.Provider>,
+        ),
+      );
+    });
+
+    const errorNotif = (await screen.findByRole("alert")) as HTMLDivElement;
+    expect(errorNotif).toBeInTheDocument();
+
+    expect(within(errorNotif).getByText(/Not connected to server!/)).toBeInTheDocument();
+    expect(screen.getByText("Something went wrong.")).toBeInTheDocument();
+
+    screen.debug(undefined, 30000);
   });
 });

--- a/__tests__/pages/resource/id/evaluate.test.tsx
+++ b/__tests__/pages/resource/id/evaluate.test.tsx
@@ -386,3 +386,40 @@ describe("Select component, Radio button, and request preview render", () => {
     ).toBeInTheDocument();
   });
 });
+
+describe.only("Error thrown during create test", () => {
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementationError("400 Bad Request");
+  });
+
+  it.only("Test for error notification when error is thrown", async () => {
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <RouterContext.Provider
+            value={createMockRouter({
+              query: { resourceType: "Measure", id: "Measure-12" },
+            })}
+          >
+            <EvaluateMeasurePage />
+          </RouterContext.Provider>,
+        ),
+      );
+    });
+
+    screen.debug(undefined, 30000);
+
+    /* const submitButton = screen.getByRole("button", {
+      name: "Submit Resource",
+    }) as HTMLButtonElement;
+
+    const codeEditor = screen.getByRole("textbox");
+
+    const errorNotif = (await screen.findByRole("alert")) as HTMLDivElement;
+    expect(errorNotif).toBeInTheDocument();
+
+    expect(within(errorNotif).getByText(/Problem connecting to server:/)).toBeInTheDocument();
+    expect(within(errorNotif).getByText(/400 Bad Request/)).toBeInTheDocument();
+    */
+  });
+});

--- a/__tests__/pages/resource/id/evaluate.test.tsx
+++ b/__tests__/pages/resource/id/evaluate.test.tsx
@@ -374,6 +374,7 @@ describe("non 20x response in evaluate measure page", () => {
     const errorNotif = (await screen.findByRole("alert")) as HTMLDivElement;
     expect(errorNotif).toBeInTheDocument();
 
+    expect(screen.queryByTestId("prism-measure-report")).not.toBeInTheDocument();
     expect(within(errorNotif).getByText(/400 BadRequest/)).toBeInTheDocument();
     expect(within(errorNotif).getByText(/Invalid resource ID/)).toBeInTheDocument();
   });
@@ -402,19 +403,20 @@ describe("Evaluate measure page fetch throws error", () => {
     const errorNotif = (await screen.findByRole("alert")) as HTMLDivElement;
     expect(errorNotif).toBeInTheDocument();
 
+    expect(screen.queryByTestId("prism-measure-report")).not.toBeInTheDocument();
     expect(within(errorNotif).getByText(/Not connected to server!/)).toBeInTheDocument();
     expect(screen.getByText("Something went wrong.")).toBeInTheDocument();
   });
 });
 
-describe.only("Evaluate measure successful request", () => {
+describe("Evaluate measure successful request", () => {
   beforeAll(() => {
     global.fetch = getMockFetchImplementation(MEASURE_BODY_NO_EFFECTIVE_PERIOD);
   });
 
   window.ResizeObserver = mockResizeObserver;
 
-  it.only("should display success notif and Prism component with MeasureReport", async () => {
+  it("should display success notif and Prism component with fetch response json body", async () => {
     await act(async () => {
       render(
         mantineRecoilWrap(

--- a/__tests__/pages/resource/id/evaluate.test.tsx
+++ b/__tests__/pages/resource/id/evaluate.test.tsx
@@ -328,14 +328,15 @@ describe("Select component, Radio button, and request preview render", () => {
         </RouterContext.Provider>,
       );
     });
-    //click the population radio button to ensure the Patient autocomplete component doesn't appear
+    //click the population radio button to disable Patient autocomplete component
     const populationRadio = screen.getByLabelText("Population");
+
     //Population radio button should not be pre-selected
     expect(populationRadio).not.toBeChecked();
     await act(async () => {
       fireEvent.click(populationRadio);
     });
-    expect(screen.queryByText("Select Patient")).not.toBeInTheDocument;
+    expect(screen.getByRole("searchbox", { name: "Select Patient" })).toBeDisabled();
 
     //expect the request preview to include reportType=population
     expect(

--- a/components/MeasureDatePickers.tsx
+++ b/components/MeasureDatePickers.tsx
@@ -94,8 +94,8 @@ const MeasureDatePickers = ({
 
   if (!fetchingError) {
     return (
-      <Grid gutter="lg" min-width="15px">
-        <Grid.Col md={6} lg={6} xl={6}>
+      <Grid columns={4}>
+        <Grid.Col span={2}>
           <DatePicker
             label={<Text size="lg">Period Start</Text>}
             icon={<Calendar size={16} color={"#40a5bf"} />}
@@ -107,7 +107,7 @@ const MeasureDatePickers = ({
             allowFreeInput
           ></DatePicker>
         </Grid.Col>
-        <Grid.Col md={6} lg={6} xl={6}>
+        <Grid.Col span={2}>
           <DatePicker
             label={<Text size="lg">Period End</Text>}
             variant="filled"

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -94,7 +94,7 @@ const EvaluateMeasurePage = () => {
     if (!fetchingError) {
       //for resourceType Measure, evaluate measure components are rendered
       return (
-        <>
+        <div>
           <BackButton />
           <Center>
             <h2 style={{ color: textGray, marginTop: "0px", marginBottom: "4px" }}>
@@ -102,101 +102,6 @@ const EvaluateMeasurePage = () => {
             </h2>
           </Center>
           <Divider my="md" />
-          <MeasureDatePickers
-            measureID={id as string}
-            periodStart={periodStart}
-            periodEnd={periodEnd}
-            startOnUpdate={setPeriodStart}
-            endOnUpdate={setPeriodEnd}
-          />
-          <RadioGroup
-            value={radioValue}
-            onChange={setRadioValue}
-            label="Select Subject or Population"
-            required
-          >
-            <Radio value="Subject" label="Subject" />
-            <Radio value="Population" label="Population" />
-          </RadioGroup>
-          {/* only displays autocomplete component if radio value is Patient */}
-          {radioValue === "Subject" ? (
-            <SelectComponent
-              resourceType="Patient"
-              setValue={setPatientValue}
-              value={patientValue}
-            />
-          ) : null}
-          <SelectComponent
-            resourceType="Practitioner"
-            setValue={setPractitionerValue}
-            value={practitionerValue}
-          />
-          <h3 style={{ color: textGray, marginTop: "20px", marginBottom: "2px" }}>
-            Request Preview:
-          </h3>
-          <Text
-            size="md"
-            style={{ backgroundColor: "#e3fafc", color: textGray }}
-          >{`${createRequestPreview()}`}</Text>
-
-          <Button
-            disabled={!validSelections()}
-            color="cyan"
-            radius="md"
-            size="sm"
-            variant="filled"
-            style={{
-              marginRight: "8px",
-              marginLeft: "8px",
-            }}
-            onClick={calculateHandler}
-          >
-            Calculate
-          </Button>
-          {loadingRequest && (
-            <Center>
-              <div>Loading content...</div>
-              <Loader color="cyan"></Loader>
-            </Center>
-          )}
-          {measureReportBody && !loadingRequest && (
-            <>
-              <Divider my="sm" />
-              <ScrollArea>
-                <MantineProvider
-                  //changes hex values associated with each Mantine color name to improve UI
-                  theme={{
-                    colors: {
-                      gray: replaceGray,
-                      dark: replaceDark,
-                      teal: replaceTeal,
-                      red: replaceRed,
-                      blue: replaceBlue,
-                    },
-                  }}
-                >
-                  <Prism
-                    language="json"
-                    data-testid="prism-measure-report"
-                    colorScheme="dark"
-                    style={{ maxWidth: "77vw", height: "80vh", backgroundColor: "#FFFFFF" }}
-                  >
-                    {measureReportBody}
-                  </Prism>
-                </MantineProvider>
-              </ScrollArea>
-            </>
-          )}
-        </>
-      );
-    } else if (loadingRequest && !fetchingError) {
-      return (
-        // <Center>
-        //   <div>Loading content...</div>
-        //   <Loader color="cyan"></Loader>
-        // </Center>
-        // <Divider my="md" />
-        <div>
           <Grid columns={3} style={{ margin: 15 }}>
             <MantineProvider
               // changes hex values associated with each Mantine color name to improve UI
@@ -265,7 +170,7 @@ const EvaluateMeasurePage = () => {
                     textAlign: "center",
                   }}
                 >
-                  Request Preview:{" "}
+                  Request Preview:
                 </h3>
                 <div
                   style={{
@@ -293,19 +198,58 @@ const EvaluateMeasurePage = () => {
                   }}
                 >
                   <Button
+                    disabled={!validSelections()}
                     color="cyan"
-                    radius="lg"
-                    size="md"
+                    radius="md"
+                    size="sm"
+                    variant="filled"
                     style={{
-                      textAlign: "center",
+                      marginRight: "8px",
+                      marginLeft: "8px",
                     }}
+                    onClick={calculateHandler}
                   >
-                    Sample Submit Button
+                    Calculate
                   </Button>
                 </div>
               </Grid.Col>
             </MantineProvider>
           </Grid>
+
+          {loadingRequest && (
+            <Center>
+              <div>Loading content...</div>
+              <Loader color="cyan"></Loader>
+            </Center>
+          )}
+          {measureReportBody && !loadingRequest && (
+            <>
+              <Divider my="sm" />
+              <ScrollArea>
+                <MantineProvider
+                  //changes hex values associated with each Mantine color name to improve UI
+                  theme={{
+                    colors: {
+                      gray: replaceGray,
+                      dark: replaceDark,
+                      teal: replaceTeal,
+                      red: replaceRed,
+                      blue: replaceBlue,
+                    },
+                  }}
+                >
+                  <Prism
+                    language="json"
+                    data-testid="prism-measure-report"
+                    colorScheme="dark"
+                    style={{ maxWidth: "77vw", height: "80vh", backgroundColor: "#FFFFFF" }}
+                  >
+                    {measureReportBody}
+                  </Prism>
+                </MantineProvider>
+              </ScrollArea>
+            </>
+          )}
         </div>
       );
     } else {
@@ -369,6 +313,7 @@ const EvaluateMeasurePage = () => {
               </Text>
             </>
           );
+          setMeasureReportBody("");
           setFetchingError(false);
           setLoadingRequest(false);
         } else {
@@ -379,6 +324,7 @@ const EvaluateMeasurePage = () => {
         }
       })
       .catch((error) => {
+        setMeasureReportBody("");
         setFetchingError(true);
         customMessage = (
           <>

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -42,6 +42,8 @@ const DEFAULT_PERIOD_END = new Date(`${DateTime.now().year}-12-31T00:00:00`);
  * The DatePickers are pre-filled with a Measure's effective period dates or default dates.
  * The Patient SelectComponent only appears if the reportType selected is "Subject".
  * If the url resourceType is not a Measure, an error message is displayed.
+ * If the Evaluate Measure request succeeds, a Prism component with the MeasureReport is rendered.
+ * If the Evaluate Measure request fails, an error notification appears instead.
  * @returns React node with a back button, MeasureDatePickers, SelectComponents, a RadioGroup, and Text for the request preview
  */
 const EvaluateMeasurePage = () => {
@@ -81,8 +83,8 @@ const EvaluateMeasurePage = () => {
   //only appears on the measure page
   const validSelections = () => {
     if (
-      (periodStart && periodEnd && radioValue === "Population" && practitionerValue) ||
-      (periodStart && periodEnd && radioValue === "Subject" && practitionerValue && patientValue)
+      (periodStart && periodEnd && radioValue === "Population") ||
+      (periodStart && periodEnd && radioValue === "Subject" && patientValue)
     ) {
       return true;
     } else return false;
@@ -175,7 +177,7 @@ const EvaluateMeasurePage = () => {
                 >
                   <Prism
                     language="json"
-                    data-testid="prism-page-content"
+                    data-testid="prism-measure-report"
                     colorScheme="dark"
                     style={{ maxWidth: "77vw", height: "80vh", backgroundColor: "#FFFFFF" }}
                   >
@@ -333,10 +335,8 @@ const EvaluateMeasurePage = () => {
     };
     let fetchStatus = { status: 500, statusText: "Failed fetch request" };
     setLoadingRequest(true);
-    //${process.env.NEXT_PUBLIC_DEQM_SERVER}/${createRequestPreview}
-    fetch(
-      `${process.env.NEXT_PUBLIC_DEQM_SERVER}/Measure/measure-EXM130-7.3.000/$evaluate-measure?periodStart=2019-01-01T05:00:00.000Z&periodEnd=2019-12-31T05:00:00.000Z&subject=Patient%2Fdenom-EXM130&reportType=individual`,
-    )
+
+    fetch(`${process.env.NEXT_PUBLIC_DEQM_SERVER}/${createRequestPreview}`)
       .then((response) => {
         fetchStatus = { status: response.status, statusText: response.statusText };
         return response.json();

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -329,7 +329,7 @@ const EvaluateMeasurePage = () => {
     setLoadingRequest(true);
     //${process.env.NEXT_PUBLIC_DEQM_SERVER}/${createRequestPreview}
     fetch(
-      `${process.env.NEXT_PUBLIC_DEQM_SERVER}/Measure/measure-EXM104-8.2.000/$evaluate-measure?periodStart=2022-01-12T05:00:00.000Z&periodEnd=2019-05-02T04:00:00.000Z&reportType=individual&subject=Patient/numer-EXM104`,
+      `${process.env.NEXT_PUBLIC_DEQM_SERVER}/Measure/measure-EXM104-8.2.000/$evaluate-measure?periodStart=2022-01-12T05:00:00.000Z&periodEnd=2019-05-02T04:00:00.000Z&reportType=individual`,
     )
       .then((response) => {
         //console.log("response: ", response);

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -336,7 +336,7 @@ const EvaluateMeasurePage = () => {
     let fetchStatus = { status: 500, statusText: "Failed fetch request" };
     setLoadingRequest(true);
 
-    fetch(`${process.env.NEXT_PUBLIC_DEQM_SERVER}/${createRequestPreview}`)
+    fetch(`${process.env.NEXT_PUBLIC_DEQM_SERVER}${createRequestPreview()}`)
       .then((response) => {
         fetchStatus = { status: response.status, statusText: response.statusText };
         return response.json();

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -204,10 +204,6 @@ const EvaluateMeasurePage = () => {
                       radius="md"
                       size="sm"
                       variant="filled"
-                      // style={{
-                      //   marginRight: "8px",
-                      //   marginLeft: "8px",
-                      // }}
                       onClick={calculateHandler}
                     >
                       Calculate
@@ -224,7 +220,6 @@ const EvaluateMeasurePage = () => {
                 )}
                 {measureReportBody && !loadingRequest && (
                   <>
-                    {/* <Divider my="sm" /> */}
                     <ScrollArea>
                       <MantineProvider
                         //changes hex values associated with each Mantine color name to improve UI

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -10,7 +10,7 @@ import {
   MantineProvider,
 } from "@mantine/core";
 import { useRouter } from "next/router";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { DateTime } from "luxon";
 import { textGray } from "../../../styles/appColors";
 import BackButton from "../../../components/BackButton";
@@ -59,6 +59,12 @@ const EvaluateMeasurePage = () => {
   const [patientValue, setPatientValue] = useState("");
   const [periodStart, setPeriodStart] = useState<Date>(DEFAULT_PERIOD_START);
   const [periodEnd, setPeriodEnd] = useState<Date>(DEFAULT_PERIOD_END);
+
+  useEffect(() => {
+    if (radioValue === "Population") {
+      setPatientValue("");
+    }
+  }, [radioValue]);
 
   /**
    * createRequestPreview builds the request preview with the evaluate measure state variables

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -4,9 +4,10 @@ import {
   RadioGroup,
   Radio,
   Text,
-  MantineProvider,
   Button,
   Loader,
+  ScrollArea,
+  MantineProvider,
 } from "@mantine/core";
 import { useRouter } from "next/router";
 import React, { useState } from "react";
@@ -23,6 +24,14 @@ import {
 } from "../../../styles/codeColorScheme";
 import { cleanNotifications, showNotification, NotificationProps } from "@mantine/notifications";
 import { Check, X } from "tabler-icons-react";
+import { Prism } from "@mantine/prism";
+import {
+  replaceDark,
+  replaceGray,
+  replaceTeal,
+  replaceRed,
+  replaceBlue,
+} from "../../../styles/codeColorScheme";
 
 const DEFAULT_PERIOD_START = new Date(`${DateTime.now().year}-01-01T00:00:00`);
 const DEFAULT_PERIOD_END = new Date(`${DateTime.now().year}-12-31T00:00:00`);
@@ -41,7 +50,8 @@ const EvaluateMeasurePage = () => {
   const [radioValue, setRadioValue] = useState("Subject");
   const [fetchingError, setFetchingError] = useState(false);
   const [loadingRequest, setLoadingRequest] = useState(false);
-  const [pageBody, setPageBody] = useState("");
+  const [measureReportBody, setMeasureReportBody] = useState("");
+
   const [practitionerValue, setPractitionerValue] = useState("");
   const [patientValue, setPatientValue] = useState("");
   const [periodStart, setPeriodStart] = useState<Date>(DEFAULT_PERIOD_START);
@@ -77,13 +87,6 @@ const EvaluateMeasurePage = () => {
       return true;
     } else return false;
   };
-  // ((periodStart && periodEnd && radioValue === "Population" && practitionerValue) as boolean) ||
-  // ((periodStart &&
-  //   periodEnd &&
-  //   radioValue === "Subject" &&
-  //   practitionerValue &&
-  //   patientValue) as boolean);
-  console.log("validSelections:", validSelections());
 
   if (resourceType === "Measure" && id) {
     if (!loadingRequest && !fetchingError) {
@@ -148,6 +151,34 @@ const EvaluateMeasurePage = () => {
           >
             <div>Calculate</div>
           </Button>
+          {measureReportBody && (
+            <>
+              <Divider my="sm" />
+              <ScrollArea>
+                <MantineProvider
+                  //changes hex values associated with each Mantine color name to improve UI
+                  theme={{
+                    colors: {
+                      gray: replaceGray,
+                      dark: replaceDark,
+                      teal: replaceTeal,
+                      red: replaceRed,
+                      blue: replaceBlue,
+                    },
+                  }}
+                >
+                  <Prism
+                    language="json"
+                    data-testid="prism-page-content"
+                    colorScheme="dark"
+                    style={{ maxWidth: "77vw", height: "80vh", backgroundColor: "#FFFFFF" }}
+                  >
+                    {measureReportBody}
+                  </Prism>
+                </MantineProvider>
+              </ScrollArea>
+            </>
+          )}
         </>
       );
     } else if (loadingRequest && !fetchingError) {
@@ -301,7 +332,7 @@ const EvaluateMeasurePage = () => {
       `${process.env.NEXT_PUBLIC_DEQM_SERVER}/Measure/measure-EXM104-8.2.000/$evaluate-measure?periodStart=2022-01-12T05:00:00.000Z&periodEnd=2019-05-02T04:00:00.000Z&reportType=individual&subject=Patient/numer-EXM104`,
     )
       .then((response) => {
-        console.log("response: ", response);
+        //console.log("response: ", response);
         if (response.status === 201 || response.status === 200) {
           customMessage = (
             <>
@@ -326,10 +357,10 @@ const EvaluateMeasurePage = () => {
         return response.json();
       })
       .then((responseBody) => {
-        console.log("responseBody: ", responseBody);
+        //console.log("responseBody: ", responseBody);
         if (responseBody) {
-          setPageBody(JSON.stringify(responseBody));
-          console.log("pageBody: ", pageBody);
+          setMeasureReportBody(JSON.stringify(responseBody, null, 2));
+          console.log("measureReport: ", measureReportBody);
           setFetchingError(false);
           setLoadingRequest(false);
         } else {

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -53,6 +53,7 @@ const EvaluateMeasurePage = () => {
   const [fetchingError, setFetchingError] = useState(false);
   const [loadingRequest, setLoadingRequest] = useState(false);
   const [measureReportBody, setMeasureReportBody] = useState("");
+  const [gridColSpans, setGridColSpans] = useState([3, 3, 0]);
 
   const [practitionerValue, setPractitionerValue] = useState("");
   const [patientValue, setPatientValue] = useState("");
@@ -102,7 +103,7 @@ const EvaluateMeasurePage = () => {
             </h2>
           </Center>
           <Divider my="md" />
-          <Grid columns={3} style={{ margin: 15 }}>
+          <Grid columns={gridColSpans[0]}>
             <MantineProvider
               // changes hex values associated with each Mantine color name to improve UI
               theme={{
@@ -113,143 +114,145 @@ const EvaluateMeasurePage = () => {
                 },
               }}
             >
-              <Grid.Col span={3}>
-                <Grid.Col span={3} style={{ minHeight: 100, margin: 5 }}>
-                  <MeasureDatePickers
-                    measureID={id as string}
-                    periodStart={periodStart}
-                    periodEnd={periodEnd}
-                    startOnUpdate={setPeriodStart}
-                    endOnUpdate={setPeriodEnd}
-                  />
-                </Grid.Col>
-                <Grid.Col span={3} style={{ margin: 5 }}>
-                  <RadioGroup
-                    value={radioValue}
-                    onChange={setRadioValue}
-                    label={<Text size="lg">Select a reportType</Text>}
-                    style={{ marginBottom: "25px" }}
-                  >
-                    <Radio value="Subject" label="Subject" />
-                    <Radio value="Population" label="Population" />
-                  </RadioGroup>
-
-                  {/* only displays autocomplete component if radio value is Patient */}
-                  {radioValue === "Subject" ? (
-                    <SelectComponent
-                      resourceType="Patient"
-                      setValue={setPatientValue}
-                      value={patientValue}
-                      required={true}
+              <Grid.Col span={gridColSpans[1]}>
+                <Grid.Col>
+                  <Grid.Col style={{ minHeight: 100 }}>
+                    <MeasureDatePickers
+                      measureID={id as string}
+                      periodStart={periodStart}
+                      periodEnd={periodEnd}
+                      startOnUpdate={setPeriodStart}
+                      endOnUpdate={setPeriodEnd}
                     />
-                  ) : (
-                    <SelectComponent
-                      resourceType="Patient"
-                      setValue={setPatientValue}
-                      value={patientValue}
-                      disabled={true}
-                      placeholder="Patient selection disabled when 'Population' is selected"
-                    />
-                  )}
-                </Grid.Col>
+                  </Grid.Col>
+                  <Grid.Col>
+                    <RadioGroup
+                      value={radioValue}
+                      onChange={setRadioValue}
+                      label={<Text size="lg">Select a reportType</Text>}
+                      style={{ marginBottom: "25px" }}
+                    >
+                      <Radio value="Subject" label="Subject" />
+                      <Radio value="Population" label="Population" />
+                    </RadioGroup>
 
-                <Grid.Col span={3} style={{ margin: 5 }}>
-                  <SelectComponent
-                    resourceType="Practitioner"
-                    setValue={setPractitionerValue}
-                    value={practitionerValue}
-                  />
+                    {/* only displays autocomplete component if radio value is Patient */}
+                    {radioValue === "Subject" ? (
+                      <SelectComponent
+                        resourceType="Patient"
+                        setValue={setPatientValue}
+                        value={patientValue}
+                        required={true}
+                      />
+                    ) : (
+                      <SelectComponent
+                        resourceType="Patient"
+                        setValue={setPatientValue}
+                        value={patientValue}
+                        disabled={true}
+                        placeholder="Patient selection disabled when 'Population' is selected"
+                      />
+                    )}
+                  </Grid.Col>
+                  <Grid.Col>
+                    <SelectComponent
+                      resourceType="Practitioner"
+                      setValue={setPractitionerValue}
+                      value={practitionerValue}
+                    />
+                  </Grid.Col>
                 </Grid.Col>
-              </Grid.Col>
-              <Grid.Col span={3} style={{ margin: 5 }}>
-                <h3
-                  style={{
-                    color: textGray,
-                    marginTop: "20px",
-                    marginBottom: "2px",
-                    textAlign: "center",
-                  }}
-                >
-                  Request Preview:
-                </h3>
-                <div
-                  style={{
-                    textAlign: "center",
-                    overflowWrap: "break-word",
-                    padding: "10px",
-                    backgroundColor: "#F1F3F5",
-                    border: "1px solid",
-                    borderColor: "#4a4f4f",
-                    borderRadius: "20px",
-                    marginLeft: "30px",
-                    marginRight: "30px",
-                  }}
-                >
-                  <Text
-                    size="md"
-                    style={{ color: textGray, textAlign: "left" }}
-                  >{`${createRequestPreview()}`}</Text>
-                </div>
-              </Grid.Col>
-              <Grid.Col span={3} style={{ minHeight: 100, margin: 5 }}>
-                <div
-                  style={{
-                    textAlign: "center",
-                  }}
-                >
-                  <Button
-                    disabled={!validSelections()}
-                    color="cyan"
-                    radius="md"
-                    size="sm"
-                    variant="filled"
+                <Grid.Col>
+                  <h3
                     style={{
-                      marginRight: "8px",
-                      marginLeft: "8px",
+                      color: textGray,
+                      marginTop: "20px",
+                      marginBottom: "2px",
+                      textAlign: "center",
                     }}
-                    onClick={calculateHandler}
                   >
-                    Calculate
-                  </Button>
-                </div>
+                    Request Preview:
+                  </h3>
+                  <div
+                    style={{
+                      textAlign: "center",
+                      overflowWrap: "break-word",
+                      padding: "10px",
+                      backgroundColor: "#F1F3F5",
+                      border: "1px solid",
+                      borderColor: "#4a4f4f",
+                      borderRadius: "20px",
+                      marginLeft: "30px",
+                      marginRight: "30px",
+                    }}
+                  >
+                    <Text
+                      size="md"
+                      style={{ color: textGray, textAlign: "left" }}
+                    >{`${createRequestPreview()}`}</Text>
+                  </div>
+                </Grid.Col>
+                <Grid.Col style={{ minHeight: 100 }}>
+                  <div
+                    style={{
+                      textAlign: "center",
+                    }}
+                  >
+                    <Button
+                      disabled={!validSelections()}
+                      color="cyan"
+                      radius="md"
+                      size="sm"
+                      variant="filled"
+                      // style={{
+                      //   marginRight: "8px",
+                      //   marginLeft: "8px",
+                      // }}
+                      onClick={calculateHandler}
+                    >
+                      Calculate
+                    </Button>
+                  </div>
+                </Grid.Col>
+              </Grid.Col>
+              <Grid.Col span={gridColSpans[2]}>
+                {loadingRequest && (
+                  <Center>
+                    <div>Loading content...</div>
+                    <Loader color="cyan"></Loader>
+                  </Center>
+                )}
+                {measureReportBody && !loadingRequest && (
+                  <>
+                    {/* <Divider my="sm" /> */}
+                    <ScrollArea>
+                      <MantineProvider
+                        //changes hex values associated with each Mantine color name to improve UI
+                        theme={{
+                          colors: {
+                            gray: replaceGray,
+                            dark: replaceDark,
+                            teal: replaceTeal,
+                            red: replaceRed,
+                            blue: replaceBlue,
+                          },
+                        }}
+                      >
+                        <Prism
+                          language="json"
+                          data-testid="prism-measure-report"
+                          colorScheme="dark"
+                          style={{ maxWidth: "77vw", height: "80vh", backgroundColor: "#FFFFFF" }}
+                        >
+                          {measureReportBody}
+                        </Prism>
+                      </MantineProvider>
+                    </ScrollArea>
+                  </>
+                )}
               </Grid.Col>
             </MantineProvider>
           </Grid>
-
-          {loadingRequest && (
-            <Center>
-              <div>Loading content...</div>
-              <Loader color="cyan"></Loader>
-            </Center>
-          )}
-          {measureReportBody && !loadingRequest && (
-            <>
-              <Divider my="sm" />
-              <ScrollArea>
-                <MantineProvider
-                  //changes hex values associated with each Mantine color name to improve UI
-                  theme={{
-                    colors: {
-                      gray: replaceGray,
-                      dark: replaceDark,
-                      teal: replaceTeal,
-                      red: replaceRed,
-                      blue: replaceBlue,
-                    },
-                  }}
-                >
-                  <Prism
-                    language="json"
-                    data-testid="prism-measure-report"
-                    colorScheme="dark"
-                    style={{ maxWidth: "77vw", height: "80vh", backgroundColor: "#FFFFFF" }}
-                  >
-                    {measureReportBody}
-                  </Prism>
-                </MantineProvider>
-              </ScrollArea>
-            </>
-          )}
         </div>
       );
     } else {
@@ -298,6 +301,7 @@ const EvaluateMeasurePage = () => {
             icon: <Check size={18} />,
           };
           setMeasureReportBody(JSON.stringify(responseBody, null, 2));
+          setGridColSpans([8, 3, 5]);
           setFetchingError(false);
           setLoadingRequest(false);
         } else if (fetchStatus.status > 299) {
@@ -314,6 +318,7 @@ const EvaluateMeasurePage = () => {
             </>
           );
           setMeasureReportBody("");
+          setGridColSpans([3, 3, 0]);
           setFetchingError(false);
           setLoadingRequest(false);
         } else {
@@ -325,6 +330,7 @@ const EvaluateMeasurePage = () => {
       })
       .catch((error) => {
         setMeasureReportBody("");
+        setGridColSpans([3, 3, 0]);
         setFetchingError(true);
         customMessage = (
           <>

--- a/styles/codeColorScheme.tsx
+++ b/styles/codeColorScheme.tsx
@@ -84,7 +84,7 @@ export const replaceBackground: stringArray = [
   "#4a4f4f",
   "#4a4f4f;",
   "#4a4f4f",
-  "#4a4f4f",
+  "#B2B5B5",
   "#4a4f4f",
   "#4a4f4f",
   "#4a4f4f",


### PR DESCRIPTION
## Summary
Implementation of Evaluate Measure calculation (request and response handling). 
## New behavior
- A Calculate button is rendered on any Evaluate Measure page. It is only enabled if the request is valid. 
- If the Calculate button is pressed, a request is sent to the test server using the url that has been "built" by the user. 
- If the measure evaluation is successful, a success notification appears and the MeasureReport is displayed in a Prism component to the right of the Calculate button. 
- If the measure evaluation is unsuccessful, an error notification appears.

## Code changes
- **pages/[resource]/[id]/evaluate.tsx** now renders the Calculate button, Prism component, and notifications
- **__tests__/pages/resource/id/evaluate.test.tsx** unit tests added

## Testing Guidance
- See the README.md for first time setup instructions.
- Be sure to have the latest version of DEQM Test Server running
#### Test in a browser
- To start the frontend: `npm run dev` then navigate to http://localhost:3001 in a browser
1. Successful measure evaluation:
    - Choose a valid set of options to build the evaluate measure request:
      a. Choose reportType: Subject, then select a Patient  
               OR
      b. Chose reportType: Population
    - Click the Calculate button. A success notification and a Prism component with the MeasureReport should both render
2. Failed measure evaluation:
    - Choose reportType: Population, then select a Practitioner which has no Patient resources.
    - Click the Calculate button and an error notification should appear, specifying the issue.

#### Unit tests
- Run the unit tests: `npm run test`
