### PR TITLE
evaluate measure group option

### DIFF
--- a/__tests__/pages/resource/id/evaluate.test.tsx
+++ b/__tests__/pages/resource/id/evaluate.test.tsx
@@ -323,15 +323,18 @@ describe("Select component, Radio button, and request preview render", () => {
       fireEvent.click(populationRadio);
     });
 
-    //expects a group autoselect component to be in the document
-    expect(screen.getByRole("searchbox", { name: "Select Group" })).toBeInTheDocument;
+    const groupSelectComponent = screen.getByRole("searchbox", {
+      name: "Select Group",
+    });
+    await act(async () => {
+      fireEvent.change(groupSelectComponent, { target: { value: "G" } });
+    });
 
-    //expect the request preview to include reportType=population
     expect(
       screen.getByText(
         `/Measure/Measure-12/$evaluate-measure?periodStart=${DateTime.now().year}-01-01&periodEnd=${
           DateTime.now().year
-        }-12-31&reportType=population`,
+        }-12-31&reportType=population&subject=G`,
       ),
     ).toBeInTheDocument();
 

--- a/__tests__/pages/resource/id/evaluate.test.tsx
+++ b/__tests__/pages/resource/id/evaluate.test.tsx
@@ -322,7 +322,9 @@ describe("Select component, Radio button, and request preview render", () => {
     await act(async () => {
       fireEvent.click(populationRadio);
     });
-    expect(screen.getByRole("searchbox", { name: "Select Patient" })).toBeDisabled();
+
+    //expects a group autoselect component to be in the document
+    expect(screen.getByRole("searchbox", { name: "Select Group" })).toBeInTheDocument;
 
     //expect the request preview to include reportType=population
     expect(

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -41,6 +41,7 @@ const DEFAULT_PERIOD_END = new Date(`${DateTime.now().year}-12-31T00:00:00`);
  * auto-complete boxes, a text preview of the measure request, and a display of the measure report response.
  * The DatePickers are pre-filled with a Measure's effective period dates or default dates.
  * The Patient SelectComponent only appears if the reportType selected is "Subject".
+ * The Group SelectComponent only appears if the reportType selected is "Population".
  * If the url resourceType is not a Measure, an error message is displayed.
  * If the Evaluate Measure request succeeds, a Prism component with the MeasureReport is rendered.
  * If the Evaluate Measure request fails, an error notification appears instead.
@@ -75,16 +76,19 @@ const EvaluateMeasurePage = () => {
     let requestPreview = `/Measure/${id}/$evaluate-measure?periodStart=${DateTime.fromISO(
       periodStart.toISOString(),
     ).toISODate()}&periodEnd=${DateTime.fromISO(periodEnd.toISOString()).toISODate()}`;
-    if (radioValue) {
-      requestPreview += `&reportType=${radioValue.toLowerCase()}`;
-      if (radioValue.toLowerCase() === "subject" && patientValue) {
-        requestPreview += `&subject=${patientValue}`;
+      if (radioValue){
+        requestPreview += `&reportType=${radioValue.toLowerCase()}`;
+        if (radioValue.toLowerCase() === "subject" && patientValue) {
+          requestPreview += `&subject=${patientValue}`;
+        }
+        if (radioValue.toLowerCase() === "population" && groupValue){
+          requestPreview += `&subject=${groupValue}`;
+        }
       }
-    }
-    if (practitionerValue) {
-      requestPreview += `&practitioner=${practitionerValue}`;
-    }
-    return requestPreview;
+      if (practitionerValue) {
+        requestPreview += `&practitioner=${practitionerValue}`;
+      }
+      return requestPreview;
   };
 
   //only appears on the measure page
@@ -216,7 +220,7 @@ const EvaluateMeasurePage = () => {
                       <Radio value="Population" label="Population" />
                     </RadioGroup>
 
-                    {/* diplays mandatory autocomplete component for patients if radio 
+                    {/* displays mandatory autocomplete component for patients if radio 
                         value is Subject, or optional group autocomplete component if radio value is Population */}
                     {radioValue === "Subject" ? (
                       <SelectComponent
@@ -230,7 +234,6 @@ const EvaluateMeasurePage = () => {
                         resourceType="Group"
                         setValue={setGroupValue}
                         value={groupValue}
-                        placeholder="Select a group or leave this field empty to run evaluate measure on entire population"
                       />
                     )}
                   </Grid.Col>

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -76,19 +76,19 @@ const EvaluateMeasurePage = () => {
     let requestPreview = `/Measure/${id}/$evaluate-measure?periodStart=${DateTime.fromISO(
       periodStart.toISOString(),
     ).toISODate()}&periodEnd=${DateTime.fromISO(periodEnd.toISOString()).toISODate()}`;
-      if (radioValue){
-        requestPreview += `&reportType=${radioValue.toLowerCase()}`;
-        if (radioValue.toLowerCase() === "subject" && patientValue) {
-          requestPreview += `&subject=${patientValue}`;
-        }
-        if (radioValue.toLowerCase() === "population" && groupValue){
-          requestPreview += `&subject=${groupValue}`;
-        }
+    if (radioValue) {
+      requestPreview += `&reportType=${radioValue.toLowerCase()}`;
+      if (radioValue.toLowerCase() === "subject" && patientValue) {
+        requestPreview += `&subject=${patientValue}`;
       }
-      if (practitionerValue) {
-        requestPreview += `&practitioner=${practitionerValue}`;
+      if (radioValue.toLowerCase() === "population" && groupValue) {
+        requestPreview += `&subject=${groupValue}`;
       }
-      return requestPreview;
+    }
+    if (practitionerValue) {
+      requestPreview += `&practitioner=${practitionerValue}`;
+    }
+    return requestPreview;
   };
 
   //only appears on the measure page

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -56,6 +56,7 @@ const EvaluateMeasurePage = () => {
   const [gridColSpans, setGridColSpans] = useState([3, 3, 0]);
   const [practitionerValue, setPractitionerValue] = useState("");
   const [patientValue, setPatientValue] = useState("");
+  const [groupValue, setGroupValue] = useState("");
   const [periodStart, setPeriodStart] = useState<Date>(DEFAULT_PERIOD_START);
   const [periodEnd, setPeriodEnd] = useState<Date>(DEFAULT_PERIOD_END);
 
@@ -215,7 +216,8 @@ const EvaluateMeasurePage = () => {
                       <Radio value="Population" label="Population" />
                     </RadioGroup>
 
-                    {/* only displays autocomplete component if radio value is Patient */}
+                    {/* diplays mandatory autocomplete component for patients if radio 
+                        value is Subject, or optional group autocomplete component if radio value is Population */}
                     {radioValue === "Subject" ? (
                       <SelectComponent
                         resourceType="Patient"
@@ -225,11 +227,10 @@ const EvaluateMeasurePage = () => {
                       />
                     ) : (
                       <SelectComponent
-                        resourceType="Patient"
-                        setValue={setPatientValue}
-                        value={patientValue}
-                        disabled={true}
-                        placeholder="Patient selection disabled when 'Population' is selected"
+                        resourceType="Group"
+                        setValue={setGroupValue}
+                        value={groupValue}
+                        placeholder="Select a group or leave this field empty to run evaluate measure on entire population"
                       />
                     )}
                   </Grid.Col>


### PR DESCRIPTION
## Summary
On the evaluate measure page, users can now run evaluate measure on a group using an autocomplete component.  

## New behavior
The evaluate measure page now offers an autocomplete component that allows the user to select a group when the population radio button is selected. 
  
## Code changes
- **pages/[resourceType]/[id]/evaluate.tsx** renders an autocomplete component where the user can select a group. 
- **[__tests__/pages/resource/id/evaluate.test.tsx** unit tests added to file

## Testing Guidance
See the README.md for first time setup instructions.
#### Testing in browser: 
- To start the frontend: `npm run dev` then navigate to http://localhost:3001 in a browser
- Click on “Measure” from the left-hand-side navigation menu. Click on any measure, and then click the evaluate measure button. Next, select the "population" option from the radioGroup on the evaluate measure page. A group select component should show up underneath.
- Select a group from the dropdown list. Verify that the group appears in the request preview. 
- Click the calculate button. Verify that the group appears in the evaluate measure report. 
#### Unit testing: 
- Run the unit tests: `npm run test`