### PR TITLE
Care gaps request

### DIFF
--- a/__tests__/components/MeasureDatePickers.test.tsx
+++ b/__tests__/components/MeasureDatePickers.test.tsx
@@ -45,8 +45,8 @@ describe("Test evaluate page render for measure without dates in effective perio
         />,
       );
     });
-    expect(await screen.findByDisplayValue("January 1, 2022")).toBeInTheDocument();
-    expect(screen.getByDisplayValue("December 31, 2022")).toBeInTheDocument();
+    expect(screen.getByDisplayValue(`January 1, ${DateTime.now().year}`)).toBeInTheDocument();
+    expect(screen.getByDisplayValue(`December 31, ${DateTime.now().year}`)).toBeInTheDocument();
   });
 });
 
@@ -66,8 +66,8 @@ describe("Test evaluate page render for measure without effective period", () =>
         />,
       );
     });
-    expect(await screen.findByDisplayValue("January 1, 2022")).toBeInTheDocument();
-    expect(screen.getByDisplayValue("December 31, 2022")).toBeInTheDocument();
+    expect(screen.getByDisplayValue(`January 1, ${DateTime.now().year}`)).toBeInTheDocument();
+    expect(screen.getByDisplayValue(`December 31, ${DateTime.now().year}`)).toBeInTheDocument();
   });
 });
 

--- a/__tests__/pages/resource/id/care-gaps.test.tsx
+++ b/__tests__/pages/resource/id/care-gaps.test.tsx
@@ -355,6 +355,64 @@ describe("Calculate button behavior and request preview", () => {
   });
 });
 
+describe("non 20x response in evaluate measure page", () => {
+  beforeEach(() => {
+    global.fetch = getMockFetchImplementation(ERROR_400_RESPONSE_BODY, 400, "BadRequest");
+  });
+
+  it("error notification should appear with expected messages", async () => {
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <RouterContext.Provider
+            value={createMockRouter({
+              query: { resourceType: "Measure", id: "measure-EXM104-8.4.000" },
+            })}
+          >
+            <CareGapsPage />
+          </RouterContext.Provider>,
+        ),
+      );
+    });
+
+    const errorNotif = (await screen.findByRole("alert")) as HTMLDivElement;
+    expect(errorNotif).toBeInTheDocument();
+
+    expect(screen.queryByTestId("prism-measure-report")).not.toBeInTheDocument();
+    expect(within(errorNotif).getByText(/400 BadRequest/)).toBeInTheDocument();
+    expect(within(errorNotif).getByText(/Invalid resource ID/)).toBeInTheDocument();
+  });
+});
+
+describe("Evaluate measure page fetch throws error", () => {
+  beforeEach(() => {
+    global.fetch = getMockFetchImplementationError("Problem connecting to server");
+  });
+
+  it("Server error notification should appear with expected messages", async () => {
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <RouterContext.Provider
+            value={createMockRouter({
+              query: { resourceType: "Measure", id: "measure-EXM104-8.4.000" },
+            })}
+          >
+            <CareGapsPage />
+          </RouterContext.Provider>,
+        ),
+      );
+    });
+
+    const errorNotif = (await screen.findByRole("alert")) as HTMLDivElement;
+    expect(errorNotif).toBeInTheDocument();
+
+    expect(screen.queryByTestId("prism-measure-report")).not.toBeInTheDocument();
+    expect(within(errorNotif).getByText(/Not connected to server!/)).toBeInTheDocument();
+    expect(screen.getByText("Something went wrong.")).toBeInTheDocument();
+  });
+});
+
 describe("Evaluate measure successful request", () => {
   beforeAll(() => {
     global.fetch = getMockFetchImplementation(SHORT_RESOURCE_ID_BODY);
@@ -411,63 +469,5 @@ describe("Evaluate measure successful request", () => {
     expect(spanText.includes('"Practitioner"')).toBe(true);
     expect(spanText.includes('"id"')).toBe(true);
     expect(spanText.includes('"denom-EXM125-3"')).toBe(true);
-  });
-});
-
-describe("non 20x response in evaluate measure page", () => {
-  beforeEach(() => {
-    global.fetch = getMockFetchImplementation(ERROR_400_RESPONSE_BODY, 400, "BadRequest");
-  });
-
-  it("error notification should appear with expected messages", async () => {
-    await act(async () => {
-      render(
-        mantineRecoilWrap(
-          <RouterContext.Provider
-            value={createMockRouter({
-              query: { resourceType: "Measure", id: "measure-EXM104-8.4.000" },
-            })}
-          >
-            <CareGapsPage />
-          </RouterContext.Provider>,
-        ),
-      );
-    });
-
-    const errorNotif = (await screen.findByRole("alert")) as HTMLDivElement;
-    expect(errorNotif).toBeInTheDocument();
-
-    expect(screen.queryByTestId("prism-measure-report")).not.toBeInTheDocument();
-    expect(within(errorNotif).getByText(/400 BadRequest/)).toBeInTheDocument();
-    expect(within(errorNotif).getByText(/Invalid resource ID/)).toBeInTheDocument();
-  });
-});
-
-describe("Evaluate measure page fetch throws error", () => {
-  beforeEach(() => {
-    global.fetch = getMockFetchImplementationError("Problem connecting to server");
-  });
-
-  it("Server error notification should appear with expected messages", async () => {
-    await act(async () => {
-      render(
-        mantineRecoilWrap(
-          <RouterContext.Provider
-            value={createMockRouter({
-              query: { resourceType: "Measure", id: "measure-EXM104-8.4.000" },
-            })}
-          >
-            <CareGapsPage />
-          </RouterContext.Provider>,
-        ),
-      );
-    });
-
-    const errorNotif = (await screen.findByRole("alert")) as HTMLDivElement;
-    expect(errorNotif).toBeInTheDocument();
-
-    expect(screen.queryByTestId("prism-measure-report")).not.toBeInTheDocument();
-    expect(within(errorNotif).getByText(/Not connected to server!/)).toBeInTheDocument();
-    expect(screen.getByText("Something went wrong.")).toBeInTheDocument();
   });
 });

--- a/__tests__/pages/resource/id/care-gaps.test.tsx
+++ b/__tests__/pages/resource/id/care-gaps.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act, fireEvent } from "@testing-library/react";
+import { render, screen, act, within, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import {
   mantineRecoilWrap,
@@ -74,14 +74,6 @@ const SHORT_RESOURCE_ID_BODY: fhirJson.Bundle = {
       },
     },
   ],
-};
-
-const MEASURE_BODY_NO_EFFECTIVE_PERIOD = {
-  resourceType: "Measure",
-  id: "measure-EXM104-8.4.000",
-  meta: {
-    lastUpdated: "2022-07-21T18:12:25.008Z",
-  },
 };
 
 const ERROR_400_RESPONSE_BODY = { issue: [{ details: { text: "Invalid resource ID" } }] };

--- a/__tests__/pages/resource/id/evaluate.test.tsx
+++ b/__tests__/pages/resource/id/evaluate.test.tsx
@@ -181,8 +181,9 @@ describe("Test evaluate page render for measure without dates in effective perio
         </RouterContext.Provider>,
       );
     });
-    expect(await screen.findByDisplayValue("January 1, 2022")).toBeInTheDocument();
-    expect(screen.getByDisplayValue("December 31, 2022")).toBeInTheDocument();
+
+    expect(screen.getByDisplayValue(`January 1, ${DateTime.now().year}`)).toBeInTheDocument();
+    expect(screen.getByDisplayValue(`December 31, ${DateTime.now().year}`)).toBeInTheDocument();
   });
 });
 
@@ -203,8 +204,10 @@ describe("Test evaluate page render for measure without effective period", () =>
         </RouterContext.Provider>,
       );
     });
-    expect(await screen.findByDisplayValue("January 1, 2022")).toBeInTheDocument();
-    expect(screen.getByDisplayValue("December 31, 2022")).toBeInTheDocument();
+    expect(
+      await screen.findByDisplayValue(`January 1, ${DateTime.now().year}`),
+    ).toBeInTheDocument();
+    expect(screen.getByDisplayValue(`December 31, ${DateTime.now().year}`)).toBeInTheDocument();
   });
 });
 
@@ -292,7 +295,9 @@ describe("Select component, Radio button, and request preview render", () => {
     });
     expect(
       screen.getByText(
-        "/Measure/Measure-12/$evaluate-measure?periodStart=2022-01-01&periodEnd=2022-12-31&reportType=subject&subject=P&practitioner=P",
+        `/Measure/Measure-12/$evaluate-measure?periodStart=${DateTime.now().year}-01-01&periodEnd=${
+          DateTime.now().year
+        }-12-31&reportType=subject&subject=P&practitioner=P`,
       ),
     ).toBeInTheDocument();
   });
@@ -322,7 +327,9 @@ describe("Select component, Radio button, and request preview render", () => {
     //expect the request preview to include reportType=population
     expect(
       screen.getByText(
-        "/Measure/Measure-12/$evaluate-measure?periodStart=2022-01-01&periodEnd=2022-12-31&reportType=population",
+        `/Measure/Measure-12/$evaluate-measure?periodStart=${DateTime.now().year}-01-01&periodEnd=${
+          DateTime.now().year
+        }-12-31&reportType=population`,
       ),
     ).toBeInTheDocument();
 

--- a/components/MeasureDatePickers.tsx
+++ b/components/MeasureDatePickers.tsx
@@ -95,7 +95,7 @@ const MeasureDatePickers = ({
   if (!fetchingError) {
     return (
       <Grid columns={4}>
-        <Grid.Col span={2}>
+        <Grid.Col span={2} style={{ padding: "2px" }}>
           <DatePicker
             label={<Text size="lg">Period Start</Text>}
             icon={<Calendar size={16} color={"#40a5bf"} />}
@@ -107,7 +107,7 @@ const MeasureDatePickers = ({
             allowFreeInput
           ></DatePicker>
         </Grid.Col>
-        <Grid.Col span={2}>
+        <Grid.Col span={2} style={{ padding: "2px" }}>
           <DatePicker
             label={<Text size="lg">Period End</Text>}
             variant="filled"

--- a/pages/[resourceType]/[id]/care-gaps.tsx
+++ b/pages/[resourceType]/[id]/care-gaps.tsx
@@ -324,7 +324,7 @@ const CareGapsPage = () => {
                     </Text>
                   </div>
                 </Grid.Col>
-                <Grid.Col style={{ minHeight: 100 }}>
+                <Grid.Col>
                   <div
                     style={{
                       textAlign: "center",

--- a/pages/[resourceType]/[id]/care-gaps.tsx
+++ b/pages/[resourceType]/[id]/care-gaps.tsx
@@ -95,7 +95,7 @@ const CareGapsPage = () => {
     return requestPreview;
   };
 
-  //only appears on the measure page
+  //true if user has selected/entered a correct combination of inputs
   const validSelections = () => {
     if (
       (periodStart && periodEnd && radioValue === "Subject" && patientValue) ||
@@ -106,7 +106,7 @@ const CareGapsPage = () => {
   };
 
   //handles sending the care-gaps request and processes the response
-  function calculateHandler() {
+  function calculateCareGapsHandler() {
     let customMessage = <Text weight={500}>Problem connecting to server:&nbsp;</Text>;
     let notifProps: NotificationProps = {
       message: customMessage,
@@ -348,7 +348,7 @@ const CareGapsPage = () => {
                         radius="md"
                         size="sm"
                         variant="filled"
-                        onClick={calculateHandler}
+                        onClick={calculateCareGapsHandler}
                       >
                         Calculate
                       </Button>

--- a/pages/[resourceType]/[id]/care-gaps.tsx
+++ b/pages/[resourceType]/[id]/care-gaps.tsx
@@ -33,6 +33,7 @@ import {
   replaceRed,
   replaceBlue,
 } from "../../../styles/codeColorScheme";
+import { fhirJson } from "@fhir-typescript/r4-core";
 
 const DEFAULT_PERIOD_START = new Date(`${DateTime.now().year}-01-01T00:00:00`);
 const DEFAULT_PERIOD_END = new Date(`${DateTime.now().year}-12-31T00:00:00`);
@@ -98,7 +99,7 @@ const CareGapsPage = () => {
   };
 
   //handles sending the care-gaps request and processes the response
-  function calculateCareGapsHandler() {
+  const calculateCareGapsHandler = () => {
     let customMessage = <Text weight={500}>Problem connecting to server:&nbsp;</Text>;
     let notifProps: NotificationProps = {
       message: customMessage,
@@ -112,7 +113,7 @@ const CareGapsPage = () => {
     fetch(`${process.env.NEXT_PUBLIC_DEQM_SERVER}${createRequestPreview()}`)
       .then((response) => {
         fetchStatus = { status: response.status, statusText: response.statusText };
-        return response.json();
+        return response.json() as Promise<fhirJson.Measure | fhirJson.OperationOutcome>;
       })
       .then((responseBody) => {
         if (fetchStatus.status === 201 || fetchStatus.status === 200) {
@@ -131,14 +132,15 @@ const CareGapsPage = () => {
           setFetchingError(false);
           setLoadingRequest(false);
         } else if (fetchStatus.status > 299) {
+          const operationOutcomeBody = responseBody as fhirJson.OperationOutcome;
           customMessage = (
             <>
               <Text weight={500}>
                 {fetchStatus.status} {fetchStatus.statusText}&nbsp;
               </Text>
               <Text color="red">
-                {responseBody.issue
-                  ? responseBody.issue[0]?.details?.text
+                {operationOutcomeBody.issue
+                  ? operationOutcomeBody.issue[0]?.details?.text
                   : "Fetch Issue undefined."}
               </Text>
             </>
@@ -169,7 +171,7 @@ const CareGapsPage = () => {
         cleanNotifications();
         showNotification({ ...notifProps, message: customMessage });
       });
-  }
+  };
 
   if (resourceType === "Measure" && id) {
     if (!fetchingError) {
@@ -196,7 +198,7 @@ const CareGapsPage = () => {
             >
               <Grid.Col span={gridColSpans[1]}>
                 <Grid.Col>
-                  <Grid.Col style={{ minHeight: 100 }}>
+                  <Grid.Col style={{ minHeight: 90 }}>
                     <MeasureDatePickers
                       measureID={id as string}
                       periodStart={periodStart}
@@ -210,7 +212,7 @@ const CareGapsPage = () => {
                       value={radioValue}
                       onChange={setRadioValue}
                       size="lg"
-                      style={{ marginTop: "20px", marginBottom: "30px" }}
+                      style={{ marginTop: "10px", marginBottom: "20px" }}
                     >
                       <Radio
                         value="Subject"
@@ -296,7 +298,7 @@ const CareGapsPage = () => {
                   <h3
                     style={{
                       color: textGray,
-                      marginTop: "20px",
+                      marginTop: "5px",
                       marginBottom: "2px",
                       textAlign: "center",
                     }}
@@ -307,13 +309,14 @@ const CareGapsPage = () => {
                     style={{
                       textAlign: "center",
                       overflowWrap: "break-word",
-                      padding: "10px",
+                      padding: "8px",
+                      paddingLeft: "20px",
                       backgroundColor: "#F1F3F5",
                       border: "1px solid",
                       borderColor: "#4a4f4f",
                       borderRadius: "20px",
-                      marginLeft: "30px",
-                      marginRight: "30px",
+                      marginLeft: "10px",
+                      marginRight: "10px",
                     }}
                   >
                     <Text size="md" style={{ color: textGray, textAlign: "left" }}>

--- a/pages/[resourceType]/[id]/care-gaps.tsx
+++ b/pages/[resourceType]/[id]/care-gaps.tsx
@@ -51,14 +51,6 @@ const CareGapsPage = () => {
   const [programValue, setProgramValue] = useState("");
   const [periodStart, setPeriodStart] = useState<Date>(DEFAULT_PERIOD_START);
   const [periodEnd, setPeriodEnd] = useState<Date>(DEFAULT_PERIOD_END);
-  useEffect(() => {
-    if (radioValue === "Subject") {
-      setOrganizationValue("");
-      setPractitionerValue("");
-    } else if (radioValue === "Organization") {
-      setPatientValue("");
-    }
-  }, [radioValue]);
 
   useEffect(() => {
     if (radioValue === "Subject") {

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -54,7 +54,6 @@ const EvaluateMeasurePage = () => {
   const [loadingRequest, setLoadingRequest] = useState(false);
   const [measureReportBody, setMeasureReportBody] = useState("");
   const [gridColSpans, setGridColSpans] = useState([3, 3, 0]);
-
   const [practitionerValue, setPractitionerValue] = useState("");
   const [patientValue, setPatientValue] = useState("");
   const [periodStart, setPeriodStart] = useState<Date>(DEFAULT_PERIOD_START);

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -271,7 +271,7 @@ const EvaluateMeasurePage = () => {
                     >{`${createRequestPreview()}`}</Text>
                   </div>
                 </Grid.Col>
-                <Grid.Col style={{ minHeight: 100 }}>
+                <Grid.Col>
                   <div
                     style={{
                       textAlign: "center",


### PR DESCRIPTION
## Summary
Implementation of Care Gaps request preview, calculate button, and server request/response handling

## New behavior
- The "Calculate" button on the care-gaps page is conditionally enabled depending on whether the user has inputted the necessary inputs for a valid care gaps request.
- The request preview is now implemented - user's inputted values included in the preview as the user inputs them
- If the "Calculate" button is pressed, the request built in the preview is sent to the server for processing
- If the request is successful, a success notification is displayed for the user and the care gaps response is displayed in a Prism component
- If unsuccessful, an error notification is displayed

## Code changes
- **pages/[resource]/[id]/care-gaps.tsx** implements request preview and request sending 
- **__tests__/pages/resource/id/care-gaps.tsx** includes unit tests for new functionality
- **__tests__/pages/resource/id/evaluate.tsx** altered so unit tests use DateTime.now().year instead of hard-coded 2022

## Testing Guidance
- See the README.md for first time setup instructions.
#### Test in a browser
- To start the frontend: `npm run dev` then navigate to http://localhost:3001 in a browser
1. Valid navigation:
    - Click on “Measure” from the left-hand-side navigation menu. Click on any of the measure IDs. Click the “Calculate Care Gaps” button
    - The request preview and calculate button should be rendered (no "Placeholder" labels)
1. Successful care-gaps evaluation:
    - Choose a valid set of options to build the care-gaps request:
      a. Choose reportType: Subject, then select a Patient  
               OR
      b. Chose reportType: Organization, then select an Organization
    - Click the Calculate button. A success notification and a Prism component with the care-gaps report should both render
2. Failed care-gaps evaluation:
    - Create a new Measure resource with no body (from the Measure home, using the Create button).
      - Use: ` {"resourceType": "Measure"}`
    - On the care-gaps page for that new measure, click the Calculate button and an error notification should appear, specifying the issue.

#### Unit tests
- Run the unit tests: `npm run test`
