### PR TITLE
Resource id pagination

### DIFF
--- a/components/ResourceCounts.tsx
+++ b/components/ResourceCounts.tsx
@@ -69,7 +69,7 @@ const ResourceCounts = () => {
    */
   const ResourceButtonsGroup = () => {
     const buttonArray = sortResourceArray(resources).map((resourceType) => (
-      <Link href={`/${resourceType}`} key={resourceType} passHref>
+      <Link href={`/${resourceType}?page=1`} key={resourceType} passHref>
         <Button
           fullWidth
           compact

--- a/components/ResourceIDs.tsx
+++ b/components/ResourceIDs.tsx
@@ -16,12 +16,7 @@ function ResourceIDs(props: { jsonBody: fhirJson.Bundle }) {
   if (props.jsonBody.total === 0) {
     return <div>No resources found</div>;
   } else if (props.jsonBody.total && props.jsonBody.total > 0) {
-    return (
-      <div style={{ height: 500 }}>
-        <h2 style={{ color: textGray, marginTop: "0px" }}>Resource IDs:</h2>
-        {entryArray != null ? getAllIDs(entryArray) : <div>No resources</div>}
-      </div>
-    );
+    return <div>{entryArray != null ? getAllIDs(entryArray) : <div>No resources</div>}</div>;
   } else {
     return <div>Invalid JSON Body</div>;
   }

--- a/components/ResourceIDs.tsx
+++ b/components/ResourceIDs.tsx
@@ -1,7 +1,6 @@
 import { fhirJson } from "@fhir-typescript/r4-core";
 import { Button } from "@mantine/core";
 import Link from "next/link";
-import { textGray } from "../styles/appColors";
 
 /**
  * Component for displaying resource IDs as Links
@@ -13,7 +12,7 @@ import { textGray } from "../styles/appColors";
 function ResourceIDs(props: { jsonBody: fhirJson.Bundle }) {
   const entryArray = props.jsonBody.entry;
 
-  if (props.jsonBody.total === 0) {
+  if (props.jsonBody.total === 0 || entryArray == null || entryArray.length === 0) {
     return <div>No resources found</div>;
   } else if (props.jsonBody.total && props.jsonBody.total > 0) {
     return <div>{entryArray != null ? getAllIDs(entryArray) : <div>No resources</div>}</div>;

--- a/components/ResourceIDs.tsx
+++ b/components/ResourceIDs.tsx
@@ -17,8 +17,8 @@ function ResourceIDs(props: { jsonBody: fhirJson.Bundle }) {
     return <div>No resources found</div>;
   } else if (props.jsonBody.total && props.jsonBody.total > 0) {
     return (
-      <div>
-        <h2 style={{ color: textGray, marginTop: "2px" }}>Resource IDs:</h2>
+      <div style={{ height: 500 }}>
+        <h2 style={{ color: textGray, marginTop: "0px" }}>Resource IDs:</h2>
         {entryArray != null ? getAllIDs(entryArray) : <div>No resources</div>}
       </div>
     );

--- a/pages/[resourceType]/[id]/care-gaps.tsx
+++ b/pages/[resourceType]/[id]/care-gaps.tsx
@@ -38,6 +38,17 @@ import { fhirJson } from "@fhir-typescript/r4-core";
 const DEFAULT_PERIOD_START = new Date(`${DateTime.now().year}-01-01T00:00:00`);
 const DEFAULT_PERIOD_END = new Date(`${DateTime.now().year}-12-31T00:00:00`);
 
+/**
+ * CareGapsPage is a page that renders a back button, pre-filled DatePickers, radio buttons,
+ * auto-complete boxes, a text preview of the request, a calculate button, and a display of the gaps in care evaluation.
+ * The DatePickers are pre-filled with a Measure's effective period dates or default dates.
+ * The Patient SelectComponent is enabled if the selected radio button is "Subject".
+ * The Organization and Practitioner SelectComponents are enabled if the selected radio button is "Organization".
+ * If the url resourceType is not a Measure, an error message is displayed.
+ * If the Gaps in Care request succeeds, a Prism component with the evaluation is rendered. Otherwise,
+ * an error notification appears.
+ * @returns React node with a back button, MeasureDatePickers, SelectComponents, a RadioGroup, a request preview as Text, and a calculate Button
+ */
 const CareGapsPage = () => {
   const router = useRouter();
   const { resourceType, id } = router.query;

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -37,15 +37,15 @@ const DEFAULT_PERIOD_START = new Date(`${DateTime.now().year}-01-01T00:00:00`);
 const DEFAULT_PERIOD_END = new Date(`${DateTime.now().year}-12-31T00:00:00`);
 
 /**
- * EvaluateMeasurePage is a page that renders a back button pre-filled DatePickers, radio buttons,
- * auto-complete boxes, a text preview of the measure request, and a display of the measure report response.
+ * EvaluateMeasurePage is a page that renders a back button, pre-filled DatePickers, radio buttons,
+ * auto-complete boxes, a text preview of the measure request, a calculate button, and a display of the measure report response.
  * The DatePickers are pre-filled with a Measure's effective period dates or default dates.
  * The Patient SelectComponent only appears if the reportType selected is "Subject".
  * The Group SelectComponent only appears if the reportType selected is "Population".
  * If the url resourceType is not a Measure, an error message is displayed.
  * If the Evaluate Measure request succeeds, a Prism component with the MeasureReport is rendered.
  * If the Evaluate Measure request fails, an error notification appears instead.
- * @returns React node with a back button, MeasureDatePickers, SelectComponents, a RadioGroup, and Text for the request preview
+ * @returns React node with a back button, MeasureDatePickers, SelectComponents, a RadioGroup, a Request Preview as Text, and a Calculate button
  */
 const EvaluateMeasurePage = () => {
   const router = useRouter();

--- a/pages/[resourceType]/[id]/index.tsx
+++ b/pages/[resourceType]/[id]/index.tsx
@@ -15,6 +15,7 @@ import {
   replaceBlue,
   replaceDelete,
 } from "../../../styles/codeColorScheme";
+import { textGray } from "../../../styles/appColors";
 /**
  * Component which displays the JSON body of an individual resource and a back button.
  * If the resource is a Measure, an evaluate measure button is also displayed.
@@ -122,6 +123,11 @@ function ResourceIDPage() {
           <div> Update </div>
         </Button>
       </Link>
+      <Center>
+        <h2
+          style={{ color: textGray, marginTop: "0px", marginBottom: "8px" }}
+        >{`${resourceType}/${id}`}</h2>
+      </Center>
     </div>
   );
 

--- a/pages/[resourceType]/[id]/update.tsx
+++ b/pages/[resourceType]/[id]/update.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from "next/router";
 import React, { useEffect, useState } from "react";
 import ResourceCodeEditor from "../../../components/ResourceCodeEditor";
-import { Button, Center, Stack, Text, Loader } from "@mantine/core";
+import { Button, Center, Stack, Text, Loader, Divider } from "@mantine/core";
 import { textGray } from "../../../styles/appColors";
 import BackButton from "../../../components/BackButton";
 import { cleanNotifications, showNotification, NotificationProps } from "@mantine/notifications";
@@ -60,8 +60,11 @@ const UpdateResourcePage = () => {
       <BackButton />
       <Stack spacing="xs">
         <Center>
-          <h2 style={{ color: textGray, marginTop: "2px" }}> Update Resource</h2>
+          <h2 style={{ color: textGray, marginTop: "2px", marginBottom: "0px" }}>
+            Update Resource
+          </h2>
         </Center>
+        <Divider my="sm" />
         <Center>
           <Text size="md" color={textGray}>
             Edit the FHIR resource body with valid JSON. Click Update Resource to update.

--- a/pages/[resourceType]/index.tsx
+++ b/pages/[resourceType]/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import ResourceIDs from "../../components/ResourceIDs";
-import { Center, Divider, Loader, Pagination } from "@mantine/core";
+import { Center, Divider, Grid, Loader, Pagination } from "@mantine/core";
 import { fhirJson } from "@fhir-typescript/r4-core";
 import { Button } from "@mantine/core";
 import Link from "next/link";
@@ -29,7 +29,7 @@ function ResourceTypeIDs() {
 
   useEffect(() => {
     let pageUrl = `${resourceType}`;
-    if (page != null) {
+    if (page) {
       setActivePageNum(parseInt(page as string));
       pageUrl = `${resourceType}?page=${page}`;
     }
@@ -72,25 +72,25 @@ function ResourceTypeIDs() {
         paddingRight: "20px",
       }}
     >
-      <Link href={`${resourceType}/create`} key={`create-${resourceType}`} passHref>
-        <Button
-          component="a"
-          color="cyan"
-          radius="md"
-          size="md"
-          variant="filled"
-          style={{
-            float: "right",
-          }}
-        >
-          <div> Create New {`${resourceType}`} </div>
-        </Button>
-      </Link>
-      <h2 style={{ marginTop: "2px", marginBottom: "5px" }}>&nbsp;</h2>
-      {/* <Center> */}
-
-      {/* </Center> */}
-      <Divider my="md" style={{ marginTop: "20px" }} />
+      <Grid>
+        <Grid.Col span={3} offset={9}>
+          <Link href={`${resourceType}/create`} key={`create-${resourceType}`} passHref>
+            <Button
+              component="a"
+              color="cyan"
+              radius="md"
+              size="md"
+              variant="filled"
+              style={{
+                float: "right",
+              }}
+            >
+              <div> Create New {`${resourceType}`} </div>
+            </Button>
+          </Link>
+        </Grid.Col>
+      </Grid>
+      <Divider my="md" style={{ marginTop: "15px" }} />
       {loadingRequest ? ( //if loading, Loader object is returned
         <Center>
           <div>Loading content...</div>
@@ -104,7 +104,6 @@ function ResourceTypeIDs() {
               overflowWrap: "break-word",
               height: "500px",
               padding: "10px",
-              //paddingLeft: "20px",
               backgroundColor: "#FFFFFF",
               border: "1px solid",
               borderColor: "#DEE2E6",

--- a/pages/[resourceType]/index.tsx
+++ b/pages/[resourceType]/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import ResourceIDs from "../../components/ResourceIDs";
-import { Center, Loader, Stack } from "@mantine/core";
+import { Center, Loader, Pagination, Stack } from "@mantine/core";
 import { fhirJson } from "@fhir-typescript/r4-core";
 import { Button } from "@mantine/core";
 import Link from "next/link";
@@ -20,18 +20,21 @@ function ResourceTypeIDs() {
   const { resourceType } = router.query;
 
   const [pageBody, setPageBody] = useState<fhirJson.Bundle>();
+  const [activePageNum, setActivePageNum] = useState(0);
+  //const [resourceIDList, setResourceIDList] = useState();
   const [fetchingError, setFetchingError] = useState(false);
   const [loadingRequest, setLoadingRequest] = useState(false);
   useEffect(() => {
-    getResourcePage(0);
+    getResourcePage(activePageNum);
     console.log("ran useEffect");
-  });
+  }, [activePageNum]);
 
   const getResourcePage = (pageNum: number) => {
+    console.log("pageNum in getResourcePage: ", pageNum);
     const getUrl =
-      pageNum === 0
+      activePageNum === 0
         ? `${process.env.NEXT_PUBLIC_DEQM_SERVER}/${resourceType}`
-        : `${process.env.NEXT_PUBLIC_DEQM_SERVER}/${resourceType}?page=${pageNum}`;
+        : `${process.env.NEXT_PUBLIC_DEQM_SERVER}/${resourceType}?page=${activePageNum}`;
     if (resourceType) {
       setLoadingRequest(true);
       fetch(getUrl)
@@ -52,7 +55,7 @@ function ResourceTypeIDs() {
     }
   };
 
-  const allPageButtons = () => {
+  /* const allPageButtons = (pageNum: number) => {
     return pageBody?.link?.map((x, i) => {
       return (
         <Button
@@ -72,7 +75,7 @@ function ResourceTypeIDs() {
     });
   };
 
-  /* const pageButton = (whichPage: string, pageNum: number) => {
+   const pageButton = (whichPage: string, pageNum: number) => {
     return (
       <Button
         color="cyan"
@@ -124,11 +127,25 @@ function ResourceTypeIDs() {
         </Stack>
       </div>
       <ResourceIDs jsonBody={pageBody}></ResourceIDs>
-      <div>{allPageButtons}</div>
+      {/* <div>{allPageButtons}</div> */}
+      <Pagination
+        total={pageBody.total ? Math.ceil(pageBody.total / 10) : 1}
+        onChange={(num) => {
+          setActivePageNum(num);
+        }}
+        color="cyan"
+        page={activePageNum}
+        // styles={(theme) => ({
+        //   item: {
+        //     '.mantine-Pagination-item': {color: {textGray}}
+        //   },
+        // })}
+      ></Pagination>
     </div>
   ) : (
     //if error occurs in http request, error message is returned
     <div>Problem connecting to server</div>
   );
 }
+//ceiling of pageBody?.total
 export default ResourceTypeIDs;

--- a/pages/[resourceType]/index.tsx
+++ b/pages/[resourceType]/index.tsx
@@ -6,13 +6,16 @@ import { fhirJson } from "@fhir-typescript/r4-core";
 import { Button } from "@mantine/core";
 import Link from "next/link";
 
+const NUMBER_IDS_RENDERED_AT_A_TIME = 10;
+
 /**
  * Component page that renders Buttons for all IDs of a resourceType. A request is made to
  * the test server to retrieve all resources of a specified type. Then a ResourceID component is
  * returned with the Buttons for each resourceID or a "No resources found" message is displayed, or if
  * the request to the server throws an error then a "Problem connecting to server" message is displayed.
- * Loader is displayed while http request is in progress
- * @returns Loader, ResourceIDs component, or error message depending on the status of the http request made.
+ * Loader is displayed while http request is in progress. For resourceTypes with more than 10 resources,
+ * Pagination component is implemented to allow for access to all resources.
+ * @returns Loader, ResourceIDs and Pagination components, or error message depending on the status of the http request made.
  */
 function ResourceTypeIDs() {
   //get resourceType from the current url with useRouter
@@ -20,24 +23,27 @@ function ResourceTypeIDs() {
   const { resourceType } = router.query;
 
   const [pageBody, setPageBody] = useState<fhirJson.Bundle>();
-  const [activePageNum, setActivePageNum] = useState(1);
-  //const [resourceIDList, setResourceIDList] = useState();
+  const [activePageNum, setActivePageNum] = useState(0);
   const [fetchingError, setFetchingError] = useState(false);
   const [loadingRequest, setLoadingRequest] = useState(false);
   useEffect(() => {
     getResourcePage();
-    console.log("ran useEffect");
   }, [activePageNum]);
 
+  useEffect(() => {
+    setActivePageNum(0);
+    getResourcePage();
+  }, [resourceType]);
+
   const getResourcePage = () => {
-    //console.log("pageNum in getResourcePage: ", pageNum);
-    const getUrl =
-      activePageNum === 1
-        ? `${process.env.NEXT_PUBLIC_DEQM_SERVER}/${resourceType}`
-        : `${process.env.NEXT_PUBLIC_DEQM_SERVER}/${resourceType}?page=${activePageNum}`;
+    const pageUrl =
+      activePageNum === 1 || activePageNum === 0
+        ? `${resourceType}`
+        : `${resourceType}?page=${activePageNum}`;
+
     if (resourceType) {
       setLoadingRequest(true);
-      fetch(getUrl)
+      fetch(`${process.env.NEXT_PUBLIC_DEQM_SERVER}/${pageUrl}`)
         .then((data) => {
           return data.json() as Promise<fhirJson.Bundle>;
         })
@@ -45,7 +51,7 @@ function ResourceTypeIDs() {
           setPageBody(resourcePageBody);
           setFetchingError(false);
           setLoadingRequest(false);
-          router.push(`/${resourceType}`, `/${resourceType}?page=${activePageNum}`, {
+          router.push(`/${resourceType}`, `/${pageUrl}`, {
             shallow: true,
           });
         })
@@ -57,109 +63,69 @@ function ResourceTypeIDs() {
     }
   };
 
-  /* const allPageButtons = (pageNum: number) => {
-    return pageBody?.link?.map((x, i) => {
-      return (
-        <Button
-          key={`page-${i}-link`}
-          color="cyan"
-          onClick={() => getResourcePage(i)}
-          radius="md"
-          size="md"
-          variant="filled"
-          style={{
-            float: "right",
-          }}
-        >
-          <div>`${x?.relation}`</div>
-        </Button>
-      );
-    });
-  };
-
-   const pageButton = (whichPage: string, pageNum: number) => {
-    return (
-      <Button
-        color="cyan"
-        onClick={() => getResourcePage(pageNum)}
-        radius="md"
-        size="md"
-        variant="filled"
+  return (
+    <div
+      style={{
+        paddingRight: "20px",
+      }}
+    >
+      <Stack
         style={{
           float: "right",
+          paddingTop: "2px",
         }}
       >
-        {whichPage}
-      </Button>
-    );
-  }; */
-
-  /*
-if (pageBody) {
-  let renderIdPage = <div></div>
-  if (loadingRequest && !fetchingError) {
-    renderIdPage = (<Center>
-    <div>Loading content...</div>
-    <Loader color="cyan"></Loader>
-  </Center>)
-  }
-  
-} */
-
-  return loadingRequest ? ( //if loading, Loader object is returned
-    <Center>
-      <div>Loading content...</div>
-      <Loader color="cyan"></Loader>
-    </Center>
-  ) : !fetchingError && pageBody ? ( //if http request was successful, ResourceID component is returned
-    <div>
-      <div
-        style={{
-          paddingRight: "20px",
-        }}
-      >
-        <Stack
-          style={{
-            float: "right",
-          }}
-        >
-          <Link href={`${resourceType}/create`} key={`create-${resourceType}`} passHref>
-            <Button
-              component="a"
-              color="cyan"
-              radius="md"
-              size="md"
-              variant="filled"
-              style={{
-                float: "right",
-              }}
-            >
-              <div> Create New {`${resourceType}`} </div>
-            </Button>
-          </Link>
-        </Stack>
-      </div>
-      <ResourceIDs jsonBody={pageBody}></ResourceIDs>
-      {/* <div>{allPageButtons}</div> */}
-      <Center>
-        <Pagination
-          total={pageBody.total ? Math.ceil(pageBody.total / 10) : 1}
-          onChange={(num) => {
-            setActivePageNum(num);
-          }}
-          color="cyan"
-          page={activePageNum}
-          // styles={(theme) => ({
-          //   item: {
-          //     '.mantine-Pagination-item': {color: {textGray}}
-          //   },
-          // })}
-        ></Pagination>
-      </Center>
+        <Link href={`${resourceType}/create`} key={`create-${resourceType}`} passHref>
+          <Button
+            component="a"
+            color="cyan"
+            radius="md"
+            size="md"
+            variant="filled"
+            style={{
+              float: "right",
+            }}
+          >
+            <div> Create New {`${resourceType}`} </div>
+          </Button>
+        </Link>
+      </Stack>
+      {loadingRequest ? ( //if loading, Loader object is returned
+        <Center>
+          <div>Loading content...</div>
+          <Loader color="cyan"></Loader>
+        </Center>
+      ) : !fetchingError && pageBody ? ( //if http request was successful, ResourceID component is returned
+        <div>
+          <div
+            style={{
+              paddingLeft: "20px",
+            }}
+          >
+            <ResourceIDs jsonBody={pageBody}></ResourceIDs>
+          </div>
+          {pageBody.total && pageBody.link
+            ? pageBody.total > NUMBER_IDS_RENDERED_AT_A_TIME && (
+                <Center>
+                  <Pagination
+                    total={
+                      pageBody.total ? Math.ceil(pageBody.total / NUMBER_IDS_RENDERED_AT_A_TIME) : 1
+                    }
+                    onChange={(num) => {
+                      setActivePageNum(num);
+                    }}
+                    color="cyan"
+                    page={activePageNum > 0 ? activePageNum : 1}
+                  ></Pagination>
+                </Center>
+              )
+            : null}
+        </div>
+      ) : (
+        //if error occurs in http request, error message is returned
+        <div>Problem connecting to server</div>
+      )}
     </div>
-  ) : (
-    //if error occurs in http request, error message is returned
-    <div>Problem connecting to server</div>
   );
 }
 

--- a/pages/[resourceType]/index.tsx
+++ b/pages/[resourceType]/index.tsx
@@ -23,14 +23,24 @@ function ResourceTypeIDs() {
   const [fetchingError, setFetchingError] = useState(false);
   const [loadingRequest, setLoadingRequest] = useState(false);
   useEffect(() => {
+    getResourcePage(0);
+    console.log("ran useEffect");
+  });
+
+  const getResourcePage = (pageNum: number) => {
+    const getUrl =
+      pageNum === 0
+        ? `${process.env.NEXT_PUBLIC_DEQM_SERVER}/${resourceType}`
+        : `${process.env.NEXT_PUBLIC_DEQM_SERVER}/${resourceType}?page=${pageNum}`;
     if (resourceType) {
       setLoadingRequest(true);
-      fetch(`${process.env.NEXT_PUBLIC_DEQM_SERVER}/${resourceType}`)
+      fetch(getUrl)
         .then((data) => {
           return data.json() as Promise<fhirJson.Bundle>;
         })
         .then((resourcePageBody) => {
           setPageBody(resourcePageBody);
+
           setFetchingError(false);
           setLoadingRequest(false);
         })
@@ -40,8 +50,46 @@ function ResourceTypeIDs() {
           setLoadingRequest(false);
         });
     }
-  }, [resourceType]);
+  };
 
+  const allPageButtons = () => {
+    return pageBody?.link?.map((x, i) => {
+      return (
+        <Button
+          key={`page-${i}-link`}
+          color="cyan"
+          onClick={() => getResourcePage(i)}
+          radius="md"
+          size="md"
+          variant="filled"
+          style={{
+            float: "right",
+          }}
+        >
+          <div>`${x?.relation}`</div>
+        </Button>
+      );
+    });
+  };
+
+  /* const pageButton = (whichPage: string, pageNum: number) => {
+    return (
+      <Button
+        color="cyan"
+        onClick={() => getResourcePage(pageNum)}
+        radius="md"
+        size="md"
+        variant="filled"
+        style={{
+          float: "right",
+        }}
+      >
+        {whichPage}
+      </Button>
+    );
+  }; */
+
+  //console.log("pageBody:", pageBody);
   return loadingRequest ? ( //if loading, Loader object is returned
     <Center>
       <div>Loading content...</div>
@@ -76,6 +124,7 @@ function ResourceTypeIDs() {
         </Stack>
       </div>
       <ResourceIDs jsonBody={pageBody}></ResourceIDs>
+      <div>{allPageButtons}</div>
     </div>
   ) : (
     //if error occurs in http request, error message is returned

--- a/pages/[resourceType]/index.tsx
+++ b/pages/[resourceType]/index.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import ResourceIDs from "../../components/ResourceIDs";
-import { Center, Loader, Pagination, Stack } from "@mantine/core";
+import { Center, Divider, Loader, Pagination, Stack } from "@mantine/core";
 import { fhirJson } from "@fhir-typescript/r4-core";
 import { Button } from "@mantine/core";
 import Link from "next/link";
+import { textGray } from "../../styles/appColors";
 
 const NUMBER_IDS_RENDERED_AT_A_TIME = 10;
 
@@ -21,21 +22,48 @@ function ResourceTypeIDs() {
   //get resourceType from the current url with useRouter
   const router = useRouter();
   const { resourceType } = router.query;
-
+  const fullPath = router.asPath;
   const [pageBody, setPageBody] = useState<fhirJson.Bundle>();
   const [activePageNum, setActivePageNum] = useState(0);
   const [fetchingError, setFetchingError] = useState(false);
   const [loadingRequest, setLoadingRequest] = useState(false);
+
+  const PAGE_IN_URL_REGEX = new RegExp(`${resourceType}\\?page=[0-9]{1,5}`);
+  const UP_TO_5_DIGITS_REGEX = new RegExp(`[0-9]{1,5}`);
+  //const PAGE_IN_URL_REGEX = new RegExp(`[0-9]{1,5}`);
+  //${resourceType}\\?page=
+  //?page=\d{1,5}
+  //const NEW_ID_IN_HEADER_REGEX = new RegExp(`${resourceType}/[A-Za-z0-9\-\.]{1,64}`);
+
   useEffect(() => {
+    console.log("activePageNum useEffect");
     getResourcePage();
   }, [activePageNum]);
 
   useEffect(() => {
-    setActivePageNum(0);
-    getResourcePage();
+    test();
+    async function test() {
+      console.log("resourceType useEffect");
+      getResourcePage();
+      if (await urlValidation()) {
+        console.log("resourceType useEffect IF urlValidation");
+        //getResourcePage();
+      } else {
+        setActivePageNum(0);
+      }
+    }
   }, [resourceType]);
 
-  const getResourcePage = () => {
+  // useEffect(() => {
+  //   //setActivePageNum(0);
+  //   urlValidation();
+  //   //getResourcePage();
+  // }, [fullPath]);
+
+  const getResourcePage = async () => {
+    console.log("getReosurcePage");
+    let successfulRequest = false;
+    //urlValidation();
     const pageUrl =
       activePageNum === 1 || activePageNum === 0
         ? `${resourceType}`
@@ -49,19 +77,59 @@ function ResourceTypeIDs() {
         })
         .then((resourcePageBody) => {
           setPageBody(resourcePageBody);
+
           setFetchingError(false);
           setLoadingRequest(false);
+          successfulRequest = true;
           router.push(`/${resourceType}`, `/${pageUrl}`, {
             shallow: true,
           });
+          //console.log("setting pageBody: ", pageBody);
         })
         .catch((error) => {
           console.log(error.message);
           setFetchingError(true);
           setLoadingRequest(false);
+          successfulRequest = false;
         });
+      console.log("setting pageBody: ", pageBody);
+      return successfulRequest;
     }
   };
+
+  async function urlValidation() {
+    //console.log("pageBody.total: ", pageBody?.total);
+    console.log("in url validation: ", pageBody);
+    let validUrl = false;
+    await getResourcePage(); //.finally(() => {
+    if (pageBody?.total) {
+      const currUrl = fullPath;
+      console.log("currUrl: ", currUrl);
+      const regexResponse = PAGE_IN_URL_REGEX.exec(currUrl);
+      console.log("regexResponse: ", regexResponse);
+
+      if (regexResponse && regexResponse[0]) {
+        console.log("regexResponse[0]: ", regexResponse[0]);
+        const pageNumRegexResponse = UP_TO_5_DIGITS_REGEX.exec(regexResponse[0]);
+        const pageNumFromUrl = pageNumRegexResponse
+          ? (pageNumRegexResponse[0] as unknown as number)
+          : null;
+        if (
+          pageNumFromUrl &&
+          pageNumFromUrl <= Math.ceil(pageBody.total / NUMBER_IDS_RENDERED_AT_A_TIME)
+        ) {
+          console.log("pageNumFromUrl: ", pageNumFromUrl);
+          setActivePageNum(pageNumFromUrl);
+        }
+        //return true;
+        validUrl = true;
+      } else validUrl = false;
+    } else validUrl = false;
+    //});
+    return validUrl;
+  }
+
+  console.log("activePageNum line 108: ", activePageNum);
 
   return (
     <div
@@ -69,27 +137,26 @@ function ResourceTypeIDs() {
         paddingRight: "20px",
       }}
     >
-      <Stack
-        style={{
-          float: "right",
-          paddingTop: "2px",
-        }}
-      >
-        <Link href={`${resourceType}/create`} key={`create-${resourceType}`} passHref>
-          <Button
-            component="a"
-            color="cyan"
-            radius="md"
-            size="md"
-            variant="filled"
-            style={{
-              float: "right",
-            }}
-          >
-            <div> Create New {`${resourceType}`} </div>
-          </Button>
-        </Link>
-      </Stack>
+      <Link href={`${resourceType}/create`} key={`create-${resourceType}`} passHref>
+        <Button
+          component="a"
+          color="cyan"
+          radius="md"
+          size="md"
+          variant="filled"
+          style={{
+            float: "right",
+          }}
+        >
+          <div> Create New {`${resourceType}`} </div>
+        </Button>
+      </Link>
+      <Center>
+        <h2
+          style={{ color: textGray, marginTop: "0px", marginBottom: "4px" }}
+        >{`${resourceType} IDs`}</h2>
+      </Center>
+      <Divider my="md" />
       {loadingRequest ? ( //if loading, Loader object is returned
         <Center>
           <div>Loading content...</div>
@@ -99,7 +166,17 @@ function ResourceTypeIDs() {
         <div>
           <div
             style={{
+              textAlign: "left",
+              overflowWrap: "break-word",
+              height: "450px",
+              padding: "10px",
               paddingLeft: "20px",
+              backgroundColor: "#FFFFFF",
+              border: "1px solid",
+              borderColor: "#DEE2E6",
+              borderRadius: "20px",
+              marginLeft: "150px",
+              marginRight: "150px",
             }}
           >
             <ResourceIDs jsonBody={pageBody}></ResourceIDs>
@@ -114,8 +191,9 @@ function ResourceTypeIDs() {
                     onChange={(num) => {
                       setActivePageNum(num);
                     }}
+                    page={activePageNum === 0 ? 1 : activePageNum}
                     color="cyan"
-                    page={activePageNum > 0 ? activePageNum : 1}
+                    style={{ marginTop: "10px" }}
                   ></Pagination>
                 </Center>
               )

--- a/pages/[resourceType]/index.tsx
+++ b/pages/[resourceType]/index.tsx
@@ -20,19 +20,19 @@ function ResourceTypeIDs() {
   const { resourceType } = router.query;
 
   const [pageBody, setPageBody] = useState<fhirJson.Bundle>();
-  const [activePageNum, setActivePageNum] = useState(0);
+  const [activePageNum, setActivePageNum] = useState(1);
   //const [resourceIDList, setResourceIDList] = useState();
   const [fetchingError, setFetchingError] = useState(false);
   const [loadingRequest, setLoadingRequest] = useState(false);
   useEffect(() => {
-    getResourcePage(activePageNum);
+    getResourcePage();
     console.log("ran useEffect");
   }, [activePageNum]);
 
-  const getResourcePage = (pageNum: number) => {
-    console.log("pageNum in getResourcePage: ", pageNum);
+  const getResourcePage = () => {
+    //console.log("pageNum in getResourcePage: ", pageNum);
     const getUrl =
-      activePageNum === 0
+      activePageNum === 1
         ? `${process.env.NEXT_PUBLIC_DEQM_SERVER}/${resourceType}`
         : `${process.env.NEXT_PUBLIC_DEQM_SERVER}/${resourceType}?page=${activePageNum}`;
     if (resourceType) {
@@ -43,9 +43,11 @@ function ResourceTypeIDs() {
         })
         .then((resourcePageBody) => {
           setPageBody(resourcePageBody);
-
           setFetchingError(false);
           setLoadingRequest(false);
+          router.push(`/${resourceType}`, `/${resourceType}?page=${activePageNum}`, {
+            shallow: true,
+          });
         })
         .catch((error) => {
           console.log(error.message);
@@ -92,7 +94,18 @@ function ResourceTypeIDs() {
     );
   }; */
 
-  //console.log("pageBody:", pageBody);
+  /*
+if (pageBody) {
+  let renderIdPage = <div></div>
+  if (loadingRequest && !fetchingError) {
+    renderIdPage = (<Center>
+    <div>Loading content...</div>
+    <Loader color="cyan"></Loader>
+  </Center>)
+  }
+  
+} */
+
   return loadingRequest ? ( //if loading, Loader object is returned
     <Center>
       <div>Loading content...</div>
@@ -128,24 +141,26 @@ function ResourceTypeIDs() {
       </div>
       <ResourceIDs jsonBody={pageBody}></ResourceIDs>
       {/* <div>{allPageButtons}</div> */}
-      <Pagination
-        total={pageBody.total ? Math.ceil(pageBody.total / 10) : 1}
-        onChange={(num) => {
-          setActivePageNum(num);
-        }}
-        color="cyan"
-        page={activePageNum}
-        // styles={(theme) => ({
-        //   item: {
-        //     '.mantine-Pagination-item': {color: {textGray}}
-        //   },
-        // })}
-      ></Pagination>
+      <Center>
+        <Pagination
+          total={pageBody.total ? Math.ceil(pageBody.total / 10) : 1}
+          onChange={(num) => {
+            setActivePageNum(num);
+          }}
+          color="cyan"
+          page={activePageNum}
+          // styles={(theme) => ({
+          //   item: {
+          //     '.mantine-Pagination-item': {color: {textGray}}
+          //   },
+          // })}
+        ></Pagination>
+      </Center>
     </div>
   ) : (
     //if error occurs in http request, error message is returned
     <div>Problem connecting to server</div>
   );
 }
-//ceiling of pageBody?.total
+
 export default ResourceTypeIDs;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Center, Stack } from "@mantine/core";
+import { Button, Center, Divider, Stack } from "@mantine/core";
 import Link from "next/link";
 import { textGray } from "../styles/appColors";
 
@@ -6,9 +6,12 @@ export default function Home() {
   return (
     <div>
       <title> DEQM Test Server Frontend </title>
-      <Center>
-        <Stack align="center">
-          <h2 style={{ color: textGray }}>Actions:</h2>
+      <Stack spacing="xs">
+        <Center>
+          <h2 style={{ color: textGray, marginTop: "2px", marginBottom: "0px" }}>Actions:</h2>
+        </Center>
+        <Divider my="sm" />
+        <Center>
           <Link
             href={{
               pathname: "/transactionUpload",
@@ -20,8 +23,8 @@ export default function Home() {
               <div>Upload Transaction Bundle</div>
             </Button>
           </Link>
-        </Stack>
-      </Center>
+        </Center>
+      </Stack>
     </div>
   );
 }

--- a/pages/transactionUpload.tsx
+++ b/pages/transactionUpload.tsx
@@ -54,10 +54,11 @@ const TransactionUploadPage = () => {
       <BackButton />
       <Stack spacing="xs">
         <Center key="Center-1">
-          <h2 style={{ color: textGray, marginTop: "0px", marginBottom: "8px" }}>
+          <h2 style={{ color: textGray, marginTop: "2px", marginBottom: "0px" }}>
             Upload Transaction Bundle
           </h2>
         </Center>
+        <Divider my="sm" />
         <Center key="Center-2">
           <Text size="md" color={textGray}>
             Enter valid transaction bundle body. Then click the Upload button.


### PR DESCRIPTION
## Summary
Implementation of a Pagination component for browsing resource IDs of resourceTypes with more than 10 resources. 
## New behavior
On any resourceType home page where the resourceType has >10 resources, a Pagination component is rendered for navigation through all the resource IDs. 
  - The url is updated to include `?page=n` when a user navigates to any page number n.
  - If a resourceType has 10 or fewer resources, no Pagination component is rendered.
  - If a user attempts to navigate to an invalid page number (page num exceeds number of actual pages for the resourceType), then a "No resources found" message is displayed.
## Code changes
- **pages/[resource]/index.tsx**  renders pagination component 
- **__tests__/pages/resource/index.test.tsx**, unit tests added to file
- **components/ResourceIDs.tsx**, minor UI change
- **pages/[resourceType]/[id]/care-gaps.tsx**, **pages/[resourceType]/[id]/evaluate.tsx**, documentation comments updated
## Testing Guidance
- See the README.md for first time setup instructions.
#### Testing in browser: 
To start the frontend: `npm run dev` then navigate to http://localhost:3001 in a browser
- Click on a resourceType in the left hand side navigation menu that has more than 10 resources. At the home page for that resourceType, there will be 10 resource IDs rendered, along with a pagination component below the IDs.
  - Click on any numbered button in the pagination component to render that page’s resource ID list.
- Switch to a resourceType with 10 or fewer resources. There should be no pagination component rendered with the resource IDs.
- Delete a resource from a resourceType that has 11 resources to see the pagination component rendered for 11, then not rendered for 10.
- Navigate to a url with no ?page=n (i.e. http://localhost:3001/ValueSet). Page 1 of the resource IDs should be rendered.
- Navigate to a url with a ?page=n where n exceeds the number of pages for that resource. A "No resources found" message should be displayed.
#### Unit testing: 
- Run the unit tests: `npm run test`
