### PR TITLE
operation menus

### DIFF
--- a/__tests__/pages/resource/id/care-gaps.test.tsx
+++ b/__tests__/pages/resource/id/care-gaps.test.tsx
@@ -528,7 +528,7 @@ describe("Prepopulated Fields on the Evaluate Measure Page", () => {
     expect(autocomplete).toHaveValue("Practitioner/123");
   });
 
-  it("should display a group value in the select group component when a group is provided in the router query", async () => {
+  it("should display an organization value in the select organization component when an organization is provided in the router query", async () => {
     await act(async () => {
       render(
         mantineRecoilWrap(

--- a/__tests__/pages/resource/id/care-gaps.test.tsx
+++ b/__tests__/pages/resource/id/care-gaps.test.tsx
@@ -471,3 +471,83 @@ describe("Evaluate measure successful request", () => {
     expect(spanText.includes('"denom-EXM125-3"')).toBe(true);
   });
 });
+
+describe("Prepopulated Fields on the Evaluate Measure Page", () => {
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementation(RESOURCE_ID_BODY);
+  });
+  window.ResizeObserver = mockResizeObserver;
+
+  it("should display a patient value in the select patient component when a patient is provided in the router query", async () => {
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <RouterContext.Provider
+            value={createMockRouter({
+              query: {
+                resourceType: "Measure",
+                id: "measure-EXM104-8.4.000",
+                patient: "Patient/denomexcl-EXM124",
+              },
+            })}
+          >
+            <CareGapsPage />
+          </RouterContext.Provider>,
+        ),
+      );
+    });
+
+    const autocomplete = screen.getByRole("searchbox", { name: "Select Patient" }) as HTMLElement;
+    expect(autocomplete).toHaveValue("Patient/denomexcl-EXM124");
+    const subjectRadio = screen.getByLabelText("Subject");
+    expect(subjectRadio).toBeChecked();
+  });
+
+  it("should display a practitioner value in the select practitioner component when a practitioner is provided in the router query", async () => {
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <RouterContext.Provider
+            value={createMockRouter({
+              query: {
+                resourceType: "Measure",
+                id: "measure-EXM104-8.4.000",
+                practitioner: "Practitioner/123",
+              },
+            })}
+          >
+            <CareGapsPage />
+          </RouterContext.Provider>,
+        ),
+      );
+    });
+
+    const autocomplete = screen.getByRole("searchbox", {
+      name: "Select Practitioner",
+    }) as HTMLElement;
+    expect(autocomplete).toHaveValue("Practitioner/123");
+  });
+
+  it("should display a group value in the select group component when a group is provided in the router query", async () => {
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <RouterContext.Provider
+            value={createMockRouter({
+              query: {
+                resourceType: "Measure",
+                id: "measure-EXM104-8.4.000",
+                organization: "Organization/123",
+              },
+            })}
+          >
+            <CareGapsPage />
+          </RouterContext.Provider>,
+        ),
+      );
+    });
+
+    const populationRadio = screen.getByLabelText("Organization");
+    expect(populationRadio).toBeChecked();
+  });
+});

--- a/__tests__/pages/resource/id/evaluate.test.tsx
+++ b/__tests__/pages/resource/id/evaluate.test.tsx
@@ -457,3 +457,81 @@ describe("Evaluate measure successful request", () => {
     expect(spanText.includes('"2022-07-21T18:12:25.008Z"')).toBe(true);
   });
 });
+
+describe("Select component, Radio button, and request preview render", () => {
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementation(RESOURCE_ID_BODY);
+  });
+  window.ResizeObserver = mockResizeObserver;
+
+  it("should display a patient value in the select patient component when a patient is provided in the router query", async () => {
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <RouterContext.Provider
+            value={createMockRouter({
+              query: {
+                resourceType: "Measure",
+                id: "measure-EXM104-8.4.000",
+                patient: "Patient/denomexcl-EXM124",
+              },
+            })}
+          >
+            <EvaluateMeasurePage />
+          </RouterContext.Provider>,
+        ),
+      );
+    });
+
+    const autocomplete = screen.getByRole("searchbox", { name: "Select Patient" }) as HTMLElement;
+    expect(autocomplete).toHaveValue("Patient/denomexcl-EXM124");
+    const subjectRadio = screen.getByLabelText("Subject");
+    expect(subjectRadio).toBeChecked();
+  });
+
+  it("should display a practitioner value in the select practitioner component when a practitioner is provided in the router query", async () => {
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <RouterContext.Provider
+            value={createMockRouter({
+              query: {
+                resourceType: "Measure",
+                id: "measure-EXM104-8.4.000",
+                practitioner: "Practitioner/123",
+              },
+            })}
+          >
+            <EvaluateMeasurePage />
+          </RouterContext.Provider>,
+        ),
+      );
+    });
+
+    const autocomplete = screen.getByRole("searchbox", {
+      name: "Select Practitioner",
+    }) as HTMLElement;
+    expect(autocomplete).toHaveValue("Practitioner/123");
+  });
+
+  it("should display a group value in the select group component when a group is provided in the router query", async () => {
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <RouterContext.Provider
+            value={createMockRouter({
+              query: { resourceType: "Measure", id: "measure-EXM104-8.4.000", group: "Group/123" },
+            })}
+          >
+            <EvaluateMeasurePage />
+          </RouterContext.Provider>,
+        ),
+      );
+    });
+    const populationRadio = screen.getByLabelText("Population");
+    expect(populationRadio).toBeChecked();
+
+    const autocomplete = screen.getByRole("searchbox", { name: "Select Group" }) as HTMLElement;
+    expect(autocomplete).toHaveValue("Group/123");
+  });
+});

--- a/__tests__/pages/resource/id/index.test.tsx
+++ b/__tests__/pages/resource/id/index.test.tsx
@@ -41,6 +41,83 @@ describe("measure resource ID render", () => {
   });
 });
 
+describe("resource ID page specific button renders", () => {
+  window.ResizeObserver = mockResizeObserver;
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementation("");
+  });
+
+  it("should display button for evaluate measure and for care gaps on patient page", async () => {
+    await act(async () => {
+      render(
+        <RouterContext.Provider
+          value={createMockRouter({
+            query: { resourceType: "Patient", id: "Patient/123" },
+          })}
+        >
+          <ResourceIDPage />
+        </RouterContext.Provider>,
+      );
+    });
+
+    //for Patient resources, "Evaluate Measure" and "Calculate Care Gaps" buttons will be in the document
+    expect(await screen.findByRole("button", { name: "Evaluate Measure" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Care Gaps" })).toBeInTheDocument();
+  });
+
+  it("should display button for evaluate measure and for care gaps on practitioner page", async () => {
+    await act(async () => {
+      render(
+        <RouterContext.Provider
+          value={createMockRouter({
+            query: { resourceType: "Practitioner", id: "Practitioner/123" },
+          })}
+        >
+          <ResourceIDPage />
+        </RouterContext.Provider>,
+      );
+    });
+
+    //for Practitioner resources, "Evaluate Measure" and "Calculate Care Gaps" buttons will be in the document
+    expect(await screen.findByRole("button", { name: "Evaluate Measure" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Care Gaps" })).toBeInTheDocument();
+  });
+
+  it("should display button for evaluate measure on group page", async () => {
+    await act(async () => {
+      render(
+        <RouterContext.Provider
+          value={createMockRouter({
+            query: { resourceType: "Group", id: "Group/123" },
+          })}
+        >
+          <ResourceIDPage />
+        </RouterContext.Provider>,
+      );
+    });
+
+    //for Group resources, "Evaluate Measure" and "Calculate Care Gaps" buttons will be in the document
+    expect(await screen.findByRole("button", { name: "Evaluate Measure" })).toBeInTheDocument();
+  });
+
+  it("should display button for care gaps on organization page", async () => {
+    await act(async () => {
+      render(
+        <RouterContext.Provider
+          value={createMockRouter({
+            query: { resourceType: "Organization", id: "Organization/123" },
+          })}
+        >
+          <ResourceIDPage />
+        </RouterContext.Provider>,
+      );
+    });
+
+    //for Organization resources, "Evaluate Measure" and "Calculate Care Gaps" buttons will be in the document
+    expect(await screen.findByRole("button", { name: "Care Gaps" })).toBeInTheDocument();
+  });
+});
+
 describe("resource ID render", () => {
   window.ResizeObserver = mockResizeObserver;
   beforeAll(() => {

--- a/components/ResourceMenu.tsx
+++ b/components/ResourceMenu.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 export interface MenuProps {
   resourceType: string;
   id: string | string[] | undefined;
-  measureArray: (fhirJson.BundleEntry | null)[] | undefined;
+  bundleEntry: (fhirJson.BundleEntry | null)[] | undefined;
   label: string;
   url: string;
 }
@@ -17,7 +17,7 @@ export interface MenuProps {
  * @params MenuProps
  * @returns a Menu component populated with measure resource IDs
  */
-export default function ResourceMenu({ resourceType, id, measureArray, label, url }: MenuProps) {
+export default function ResourceMenu({ resourceType, id, bundleEntry, label, url }: MenuProps) {
   return (
     <Menu
       size={300}
@@ -33,7 +33,7 @@ export default function ResourceMenu({ resourceType, id, measureArray, label, ur
       }
     >
       <div>
-        {measureArray?.map((el) => {
+        {bundleEntry?.map((el) => {
           return el?.resource ? (
             <Menu.Item>
               <Link
@@ -48,7 +48,7 @@ export default function ResourceMenu({ resourceType, id, measureArray, label, ur
               </Link>
             </Menu.Item>
           ) : (
-            <Menu.Item> something went wrong </Menu.Item>
+            <Menu.Item> no available options because something went wrong </Menu.Item>
           );
         })}
       </div>

--- a/components/ResourceMenu.tsx
+++ b/components/ResourceMenu.tsx
@@ -20,6 +20,7 @@ export interface MenuProps {
 export default function ResourceMenu({ resourceType, id, measureArray, label, url }: MenuProps) {
   return (
     <Menu
+      size={300}
       style={{
         float: "right",
         marginRight: "8px",

--- a/components/ResourceMenu.tsx
+++ b/components/ResourceMenu.tsx
@@ -1,0 +1,56 @@
+import { fhirJson } from "@fhir-typescript/r4-core";
+import { Button, Menu } from "@mantine/core";
+import Link from "next/link";
+
+export interface MenuProps {
+  resourceType: string;
+  id: string | string[] | undefined;
+  measureArray: (fhirJson.BundleEntry | null)[] | undefined;
+  label: string;
+  url: string;
+}
+
+/**
+ * ResourceMenu provides a menu dropdown component of all the measures. When a
+ * measure is selected, it redirects to the evaluate measure page prepopulated
+ * with data based on the resourceType and ID values passed in to the menu component
+ * @params MenuProps
+ * @returns a Menu component populated with measure resource IDs
+ */
+export default function ResourceMenu({ resourceType, id, measureArray, label, url }: MenuProps) {
+  return (
+    <Menu
+      style={{
+        float: "right",
+        marginRight: "8px",
+        marginLeft: "8px",
+      }}
+      control={
+        <Button component="a" color="cyan" radius="md" size="sm" variant="filled">
+          {label}
+        </Button>
+      }
+    >
+      <div>
+        {measureArray?.map((el) => {
+          return el?.resource ? (
+            <Menu.Item>
+              <Link
+                href={`/${el.resource.resourceType}/${
+                  el.resource.id
+                }/${url}?${resourceType.toLowerCase()}=${resourceType}/${id}`}
+              >
+                <div>
+                  {" "}
+                  {el.resource.resourceType}/{el.resource.id}{" "}
+                </div>
+              </Link>
+            </Menu.Item>
+          ) : (
+            <Menu.Item> something went wrong </Menu.Item>
+          );
+        })}
+      </div>
+    </Menu>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1086,15 +1086,30 @@
       }
     },
     "@mantine/core": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-4.2.9.tgz",
-      "integrity": "sha512-25krgKF7FUFDsF5IYk+A/7GjgAZFzEcaFmGvscXS/7ccOickBmXzENwY9eJpv+MDo/7Sj5eiS0ZBi+WN27tdcw==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-4.2.12.tgz",
+      "integrity": "sha512-PZcVUvcSZiZmLR1moKBJFdFIh6a4C+TE2ao91kzTAlH5Qb8t/V3ONbfPk3swHoYr7OSLJQM8vZ7UD5sFDiq0/g==",
       "requires": {
-        "@mantine/styles": "4.2.9",
+        "@mantine/styles": "4.2.12",
         "@popperjs/core": "^2.9.3",
         "@radix-ui/react-scroll-area": "^0.1.1",
         "react-popper": "^2.2.5",
         "react-textarea-autosize": "^8.3.2"
+      },
+      "dependencies": {
+        "@mantine/styles": {
+          "version": "4.2.12",
+          "resolved": "https://registry.npmjs.org/@mantine/styles/-/styles-4.2.12.tgz",
+          "integrity": "sha512-9q1DzW0UNW/ORMGLHfN2XABOSEm0ZQebhNlLD757R6OQouoLuUf9elUwgGOXSyogMlsAYoy84XbJ3ZbbTm4YCA==",
+          "requires": {
+            "@emotion/cache": "11.7.1",
+            "@emotion/react": "11.7.1",
+            "@emotion/serialize": "1.0.2",
+            "@emotion/utils": "1.0.0",
+            "clsx": "^1.1.1",
+            "csstype": "3.0.9"
+          }
+        }
       }
     },
     "@mantine/dates": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@codemirror/lang-javascript": "^6.0.1",
     "@codemirror/lang-json": "^6.0.0",
     "@fhir-typescript/r4-core": "0.0.12-beta.11",
-    "@mantine/core": "^4.2.4",
+    "@mantine/core": "^4.2.12",
     "@mantine/dates": "^4.2.12",
     "@mantine/hooks": "^4.2.4",
     "@mantine/modals": "^4.2.12",

--- a/pages/[resourceType]/[id]/care-gaps.tsx
+++ b/pages/[resourceType]/[id]/care-gaps.tsx
@@ -67,14 +67,16 @@ const CareGapsPage = () => {
   //fetches patient, organization, and practitioner values from url and populates state variables accordingly
   useEffect(() => {
     setPatientValue(patient ? patient.toString() : "");
-    setRadioValue(patient ? "Subject" : radioValue);
-  }, [patient, radioValue]);
+    setRadioValue("Subject");
+  }, [patient]);
 
   useEffect(() => {
-    setRadioValue(organization || practitioner ? "Organization" : radioValue);
+    if (organization || practitioner) {
+      setRadioValue("Organization");
+    }
     setOrganizationValue(organization ? organization.toString() : "");
     setPractitionerValue(practitioner ? practitioner.toString() : "");
-  }, [organization, practitioner, radioValue]);
+  }, [organization, practitioner]);
 
   /**
    * createRequestPreview builds the request preview with the care-gaps state variables

--- a/pages/[resourceType]/[id]/care-gaps.tsx
+++ b/pages/[resourceType]/[id]/care-gaps.tsx
@@ -18,21 +18,11 @@ import BackButton from "../../../components/BackButton";
 import SelectComponent from "../../../components/SelectComponent";
 import MeasureDatePickers from "../../../components/MeasureDatePickers";
 import { Grid } from "@mantine/core";
-import {
-  replaceBackground,
-  replaceOutline,
-  replaceSecondRed,
-} from "../../../styles/codeColorScheme";
+import { shadesOfGray, shadesOfCyan, shadesOfStrawberry } from "../../../styles/codeColorScheme";
 import { Prism } from "@mantine/prism";
 import { cleanNotifications, showNotification, NotificationProps } from "@mantine/notifications";
 import { Check, X } from "tabler-icons-react";
-import {
-  replaceDark,
-  replaceGray,
-  replaceTeal,
-  replaceRed,
-  replaceBlue,
-} from "../../../styles/codeColorScheme";
+import { allWhite, AllDarkGray, allGreen, allCobalt } from "../../../styles/codeColorScheme";
 import { fhirJson } from "@fhir-typescript/r4-core";
 
 const DEFAULT_PERIOD_START = new Date(`${DateTime.now().year}-01-01T00:00:00`);
@@ -206,9 +196,9 @@ const CareGapsPage = () => {
               // changes hex values associated with each Mantine color name to improve UI
               theme={{
                 colors: {
-                  gray: replaceBackground,
-                  blue: replaceOutline,
-                  red: replaceSecondRed,
+                  gray: shadesOfGray,
+                  blue: shadesOfCyan,
+                  red: shadesOfStrawberry,
                 },
               }}
             >
@@ -349,7 +339,7 @@ const CareGapsPage = () => {
                     <MantineProvider
                       theme={{
                         colors: {
-                          cyan: replaceOutline,
+                          cyan: shadesOfCyan,
                         },
                       }}
                     >
@@ -381,11 +371,11 @@ const CareGapsPage = () => {
                         //changes hex values associated with each Mantine color name to improve UI
                         theme={{
                           colors: {
-                            gray: replaceGray,
-                            dark: replaceDark,
-                            teal: replaceTeal,
-                            red: replaceRed,
-                            blue: replaceBlue,
+                            gray: AllDarkGray,
+                            dark: allWhite,
+                            teal: shadesOfStrawberry,
+                            red: allGreen,
+                            blue: allCobalt,
                           },
                         }}
                       >

--- a/pages/[resourceType]/[id]/care-gaps.tsx
+++ b/pages/[resourceType]/[id]/care-gaps.tsx
@@ -51,7 +51,7 @@ const DEFAULT_PERIOD_END = new Date(`${DateTime.now().year}-12-31T00:00:00`);
  */
 const CareGapsPage = () => {
   const router = useRouter();
-  const { resourceType, id } = router.query;
+  const { resourceType, id, patient, practitioner, organization } = router.query;
   const [radioValue, setRadioValue] = useState("Subject");
   const [fetchingError, setFetchingError] = useState(false);
   const [loadingRequest, setLoadingRequest] = useState(false);
@@ -72,6 +72,22 @@ const CareGapsPage = () => {
       setPatientValue("");
     }
   }, [radioValue]);
+
+  //fetches patient, organization, and practitioner values from url and populates state variables accordingly
+  useEffect(() => {
+    setPatientValue(patient ? patient.toString() : "");
+    setRadioValue(patient ? "Subject" : radioValue);
+  }, [patient]);
+
+  useEffect(() => {
+    setPractitionerValue(practitioner ? practitioner.toString() : "");
+    setRadioValue(practitioner ? "Organization" : radioValue);
+  }, [practitioner]);
+
+  useEffect(() => {
+    setRadioValue(organization ? "Organization" : radioValue);
+    setOrganizationValue(organization ? organization.toString() : "");
+  }, [organization]);
 
   /**
    * createRequestPreview builds the request preview with the care-gaps state variables

--- a/pages/[resourceType]/[id]/care-gaps.tsx
+++ b/pages/[resourceType]/[id]/care-gaps.tsx
@@ -64,30 +64,17 @@ const CareGapsPage = () => {
   const [periodStart, setPeriodStart] = useState<Date>(DEFAULT_PERIOD_START);
   const [periodEnd, setPeriodEnd] = useState<Date>(DEFAULT_PERIOD_END);
 
-  useEffect(() => {
-    if (radioValue === "Subject") {
-      setOrganizationValue("");
-      setPractitionerValue("");
-    } else if (radioValue === "Organization") {
-      setPatientValue("");
-    }
-  }, [radioValue]);
-
   //fetches patient, organization, and practitioner values from url and populates state variables accordingly
   useEffect(() => {
     setPatientValue(patient ? patient.toString() : "");
     setRadioValue(patient ? "Subject" : radioValue);
-  }, [patient]);
+  }, [patient, radioValue]);
 
   useEffect(() => {
-    setPractitionerValue(practitioner ? practitioner.toString() : "");
-    setRadioValue(practitioner ? "Organization" : radioValue);
-  }, [practitioner]);
-
-  useEffect(() => {
-    setRadioValue(organization ? "Organization" : radioValue);
+    setRadioValue(organization || practitioner ? "Organization" : radioValue);
     setOrganizationValue(organization ? organization.toString() : "");
-  }, [organization]);
+    setPractitionerValue(practitioner ? practitioner.toString() : "");
+  }, [organization, practitioner, radioValue]);
 
   /**
    * createRequestPreview builds the request preview with the care-gaps state variables

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -66,17 +66,8 @@ const EvaluateMeasurePage = () => {
     setPatientValue(patient ? patient.toString() : "");
     setGroupValue(group ? group.toString() : "");
     setRadioValue(group ? "Population" : "Subject");
-  }, [patient, group]);
-
-  useEffect(() => {
-    if (radioValue === "Population") {
-      setPatientValue("");
-    }
-  }, [radioValue]);
-
-  useEffect(() => {
     setPractitionerValue(practitioner ? practitioner.toString() : "");
-  }, [practitioner]);
+  }, [patient, group, practitioner]);
 
   /**
    * createRequestPreview builds the request preview with the evaluate measure state variables

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -49,23 +49,34 @@ const DEFAULT_PERIOD_END = new Date(`${DateTime.now().year}-12-31T00:00:00`);
  */
 const EvaluateMeasurePage = () => {
   const router = useRouter();
-  const { resourceType, id } = router.query;
+  const { resourceType, id, patient, group, practitioner } = router.query;
   const [radioValue, setRadioValue] = useState("Subject");
   const [fetchingError, setFetchingError] = useState(false);
   const [loadingRequest, setLoadingRequest] = useState(false);
   const [measureReportBody, setMeasureReportBody] = useState("");
   const [gridColSpans, setGridColSpans] = useState([3, 3, 0]);
   const [practitionerValue, setPractitionerValue] = useState("");
-  const [patientValue, setPatientValue] = useState("");
+  const [patientValue, setPatientValue] = useState(patient ? patient.toString() : "");
   const [groupValue, setGroupValue] = useState("");
   const [periodStart, setPeriodStart] = useState<Date>(DEFAULT_PERIOD_START);
   const [periodEnd, setPeriodEnd] = useState<Date>(DEFAULT_PERIOD_END);
+
+  //fetches patient, group, and practitioner values from url and populates state variables accordingly
+  useEffect(() => {
+    setPatientValue(patient ? patient.toString() : "");
+    setGroupValue(group ? group.toString() : "");
+    setRadioValue(group ? "Population" : "Subject");
+  }, [patient, group]);
 
   useEffect(() => {
     if (radioValue === "Population") {
       setPatientValue("");
     }
   }, [radioValue]);
+
+  useEffect(() => {
+    setPractitionerValue(practitioner ? practitioner.toString() : "");
+  }, [practitioner]);
 
   /**
    * createRequestPreview builds the request preview with the evaluate measure state variables

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -17,21 +17,11 @@ import BackButton from "../../../components/BackButton";
 import SelectComponent from "../../../components/SelectComponent";
 import MeasureDatePickers from "../../../components/MeasureDatePickers";
 import { Grid } from "@mantine/core";
-import {
-  replaceBackground,
-  replaceOutline,
-  replaceSecondRed,
-} from "../../../styles/codeColorScheme";
+import { shadesOfGray, shadesOfCyan, shadesOfStrawberry } from "../../../styles/codeColorScheme";
 import { cleanNotifications, showNotification, NotificationProps } from "@mantine/notifications";
 import { Check, X } from "tabler-icons-react";
 import { Prism } from "@mantine/prism";
-import {
-  replaceDark,
-  replaceGray,
-  replaceTeal,
-  replaceRed,
-  replaceBlue,
-} from "../../../styles/codeColorScheme";
+import { allWhite, AllDarkGray, allGreen, allCobalt } from "../../../styles/codeColorScheme";
 
 const DEFAULT_PERIOD_START = new Date(`${DateTime.now().year}-01-01T00:00:00`);
 const DEFAULT_PERIOD_END = new Date(`${DateTime.now().year}-12-31T00:00:00`);
@@ -194,9 +184,9 @@ const EvaluateMeasurePage = () => {
               // changes hex values associated with each Mantine color name to improve UI
               theme={{
                 colors: {
-                  gray: replaceBackground,
-                  blue: replaceOutline,
-                  red: replaceSecondRed,
+                  gray: shadesOfGray,
+                  blue: shadesOfCyan,
+                  red: shadesOfStrawberry,
                 },
               }}
             >
@@ -310,11 +300,11 @@ const EvaluateMeasurePage = () => {
                         //changes hex values associated with each Mantine color name to improve UI
                         theme={{
                           colors: {
-                            gray: replaceGray,
-                            dark: replaceDark,
-                            teal: replaceTeal,
-                            red: replaceRed,
-                            blue: replaceBlue,
+                            gray: AllDarkGray,
+                            dark: allWhite,
+                            teal: shadesOfStrawberry,
+                            red: allGreen,
+                            blue: allCobalt,
                           },
                         }}
                       >

--- a/pages/[resourceType]/[id]/index.tsx
+++ b/pages/[resourceType]/[id]/index.tsx
@@ -145,29 +145,8 @@ function ResourceIDPage() {
           </Link>
         </div>
       )}
-      <Link href={`/${resourceType}/${id}/update`} key={`update-${id}`} passHref>
-        <Button
-          component="a"
-          color="cyan"
-          radius="md"
-          size="sm"
-          variant="filled"
-          style={{
-            float: "right",
-            marginRight: "8px",
-            marginLeft: "8px",
-          }}
-          key={`update-${id}`}
-        >
-          <div> Update </div>
-        </Button>
-      </Link>
-      <Center>
-        <h2
-          style={{ color: textGray, marginTop: "0px", marginBottom: "8px" }}
-        >{`${resourceType}/${id}`}</h2>
-      </Center>
-      {/** limits which pages display evaluate measure and care gap buttons based on functionality */}
+      {/** limits which pages display evaluate measure and care gap buttons */}
+      {/** both buttons display a drop down menu with measure resource options */}
       {(resourceType === "Patient" || resourceType === "Practitioner") && (
         <div>
           <ResourceMenu

--- a/pages/[resourceType]/[id]/index.tsx
+++ b/pages/[resourceType]/[id]/index.tsx
@@ -27,7 +27,7 @@ function ResourceIDPage() {
   const [fetchingError, setFetchingError] = useState(false);
   const [loadingRequest, setLoadingRequest] = useState(false);
   const [pageBody, setPageBody] = useState("");
-  const [measureArray, setMeasureArray] = useState<(fhirJson.BundleEntry | null)[]>();
+  const [bundleEntry, setBundleArray] = useState<(fhirJson.BundleEntry | null)[]>();
 
   useEffect(() => {
     if (resourceType && id) {
@@ -61,7 +61,7 @@ function ResourceIDPage() {
             return data.json() as Promise<fhirJson.Bundle>;
           })
           .then((resourcePageBody) => {
-            setMeasureArray(resourcePageBody.entry);
+            setBundleArray(resourcePageBody.entry);
             setFetchingError(false);
             setLoadingRequest(false);
           })
@@ -150,14 +150,14 @@ function ResourceIDPage() {
           <ResourceMenu
             resourceType={resourceType}
             id={id}
-            measureArray={measureArray}
+            bundleEntry={bundleEntry}
             url="evaluate"
             label="Evaluate Measure"
           />
           <ResourceMenu
             resourceType={resourceType}
             id={id}
-            measureArray={measureArray}
+            bundleEntry={bundleEntry}
             url="care-gaps"
             label="Care Gaps"
           />
@@ -168,7 +168,7 @@ function ResourceIDPage() {
           <ResourceMenu
             resourceType={resourceType}
             id={id}
-            measureArray={measureArray}
+            bundleEntry={bundleEntry}
             url="care-gaps"
             label="Care Gaps"
           />
@@ -179,7 +179,7 @@ function ResourceIDPage() {
           <ResourceMenu
             resourceType={resourceType}
             id={id}
-            measureArray={measureArray}
+            bundleEntry={bundleEntry}
             url="evaluate"
             label="Evaluate Measure"
           />

--- a/pages/[resourceType]/[id]/index.tsx
+++ b/pages/[resourceType]/[id]/index.tsx
@@ -16,6 +16,8 @@ import {
   replaceDelete,
 } from "../../../styles/codeColorScheme";
 import { textGray } from "../../../styles/appColors";
+import { fhirJson } from "@fhir-typescript/r4-core";
+import ResourceMenu from "../../../components/ResourceMenu";
 /**
  * Component which displays the JSON body of an individual resource and a back button.
  * If the resource is a Measure, an evaluate measure button is also displayed.
@@ -27,6 +29,7 @@ function ResourceIDPage() {
   const [fetchingError, setFetchingError] = useState(false);
   const [loadingRequest, setLoadingRequest] = useState(false);
   const [pageBody, setPageBody] = useState("");
+  const [measureArray, setMeasureArray] = useState<(fhirJson.BundleEntry | null)[]>();
 
   useEffect(() => {
     if (resourceType && id) {
@@ -52,6 +55,24 @@ function ResourceIDPage() {
             autoClose: false,
           });
         });
+      //fetches measure resource list from the server
+      if (resourceType) {
+        setLoadingRequest(true);
+        fetch(`${process.env.NEXT_PUBLIC_DEQM_SERVER}/Measure`)
+          .then((data) => {
+            return data.json() as Promise<fhirJson.Bundle>;
+          })
+          .then((resourcePageBody) => {
+            setMeasureArray(resourcePageBody.entry);
+            setFetchingError(false);
+            setLoadingRequest(false);
+          })
+          .catch((error) => {
+            console.log(error.message);
+            setFetchingError(true);
+            setLoadingRequest(false);
+          });
+      }
     }
   }, [resourceType, id]);
 
@@ -70,6 +91,24 @@ function ResourceIDPage() {
           <DeleteButton />
         </ModalsProvider>
       </MantineProvider>
+      <Link href={`/${resourceType}/${id}/update`} key={`update-${id}`} passHref>
+        <Button
+          component="a"
+          color="cyan"
+          radius="md"
+          size="sm"
+          variant="filled"
+          style={{
+            float: "right",
+            marginRight: "8px",
+            marginLeft: "8px",
+          }}
+          key={`update-${id}`}
+        >
+          <div> Update </div>
+        </Button>
+      </Link>
+
       {resourceType === "Measure" && (
         <div>
           <Link href={`/${resourceType}/${id}/care-gaps`} key={`care-gaps-${id}`} passHref>
@@ -128,6 +167,47 @@ function ResourceIDPage() {
           style={{ color: textGray, marginTop: "0px", marginBottom: "8px" }}
         >{`${resourceType}/${id}`}</h2>
       </Center>
+      {/** limits which pages display evaluate measure and care gap buttons based on functionality */}
+      {(resourceType === "Patient" || resourceType === "Practitioner") && (
+        <div>
+          <ResourceMenu
+            resourceType={resourceType}
+            id={id}
+            measureArray={measureArray}
+            url="evaluate"
+            label="Evaluate Measure"
+          />
+          <ResourceMenu
+            resourceType={resourceType}
+            id={id}
+            measureArray={measureArray}
+            url="care-gaps"
+            label="Care Gaps"
+          />
+        </div>
+      )}
+      {resourceType === "Organization" && (
+        <div>
+          <ResourceMenu
+            resourceType={resourceType}
+            id={id}
+            measureArray={measureArray}
+            url="care-gaps"
+            label="Care Gaps"
+          />
+        </div>
+      )}
+      {resourceType === "Group" && (
+        <div>
+          <ResourceMenu
+            resourceType={resourceType}
+            id={id}
+            measureArray={measureArray}
+            url="evaluate"
+            label="Evaluate Measure"
+          />
+        </div>
+      )}
     </div>
   );
 

--- a/pages/[resourceType]/[id]/index.tsx
+++ b/pages/[resourceType]/[id]/index.tsx
@@ -15,7 +15,6 @@ import {
   replaceBlue,
   replaceDelete,
 } from "../../../styles/codeColorScheme";
-import { textGray } from "../../../styles/appColors";
 import { fhirJson } from "@fhir-typescript/r4-core";
 import ResourceMenu from "../../../components/ResourceMenu";
 /**

--- a/pages/[resourceType]/[id]/index.tsx
+++ b/pages/[resourceType]/[id]/index.tsx
@@ -8,12 +8,11 @@ import { cleanNotifications, showNotification } from "@mantine/notifications";
 import DeleteButton from "../../../components/DeleteButton";
 import { ModalsProvider } from "@mantine/modals";
 import {
-  replaceDark,
-  replaceGray,
-  replaceTeal,
-  replaceRed,
-  replaceBlue,
-  replaceDelete,
+  allWhite,
+  AllDarkGray,
+  allGreen,
+  allCobalt,
+  shadesOfStrawberry,
 } from "../../../styles/codeColorScheme";
 import { fhirJson } from "@fhir-typescript/r4-core";
 import ResourceMenu from "../../../components/ResourceMenu";
@@ -82,7 +81,7 @@ function ResourceIDPage() {
         //changes hex values associated with each Mantine color name to improve UI
         theme={{
           colors: {
-            pink: replaceDelete,
+            pink: shadesOfStrawberry,
           },
         }}
       >
@@ -210,11 +209,11 @@ function ResourceIDPage() {
             //changes hex values associated with each Mantine color name to improve UI
             theme={{
               colors: {
-                gray: replaceGray,
-                dark: replaceDark,
-                teal: replaceTeal,
-                red: replaceRed,
-                blue: replaceBlue,
+                gray: AllDarkGray,
+                dark: allWhite,
+                teal: shadesOfStrawberry,
+                red: allGreen,
+                blue: allCobalt,
               },
             }}
           >

--- a/pages/[resourceType]/create.tsx
+++ b/pages/[resourceType]/create.tsx
@@ -10,7 +10,7 @@ import React, { useContext, useState } from "react";
 import { CountContext } from "../../components/CountContext";
 import MultiSelectComponent from "../../components/MultiSelectComponent";
 import { fhirJson } from "@fhir-typescript/r4-core";
-import { replaceBackground } from "../../styles/codeColorScheme";
+import { shadesOfGray } from "../../styles/codeColorScheme";
 
 /**
  * CreateResourcePage is a page that renders a code editor, a submit button for creating resources, and a back button.
@@ -94,7 +94,7 @@ const CreateResourcePage = () => {
               // changes hex values associated with each Mantine color name to improve UI
               theme={{
                 colors: {
-                  gray: replaceBackground,
+                  gray: shadesOfGray,
                 },
               }}
             >

--- a/pages/[resourceType]/index.tsx
+++ b/pages/[resourceType]/index.tsx
@@ -69,11 +69,21 @@ function ResourceTypeIDs() {
   return (
     <div
       style={{
-        paddingRight: "20px",
+        width: "78vw",
       }}
     >
-      <Grid>
-        <Grid.Col span={3} offset={9}>
+      <Grid columns={7}>
+        <Grid.Col offset={3} span={2} style={{ paddingTop: "5px" }}>
+          <h2
+            style={{ color: textGray, marginTop: "0px", marginBottom: "8px" }}
+          >{`${resourceType} IDs`}</h2>
+        </Grid.Col>
+        <Grid.Col
+          span={2}
+          style={{
+            paddingTop: "5px",
+          }}
+        >
           <Link href={`${resourceType}/create`} key={`create-${resourceType}`} passHref>
             <Button
               component="a"
@@ -90,7 +100,7 @@ function ResourceTypeIDs() {
           </Link>
         </Grid.Col>
       </Grid>
-      <Divider my="md" style={{ marginTop: "15px" }} />
+      <Divider my="md" style={{ marginTop: "14px" }} />
       {loadingRequest ? ( //if loading, Loader object is returned
         <Center>
           <div>Loading content...</div>
@@ -98,27 +108,26 @@ function ResourceTypeIDs() {
         </Center>
       ) : !fetchingError && pageBody ? ( //if http request was successful, ResourceID component is returned
         <div>
-          <div
-            style={{
-              textAlign: "center",
-              overflowWrap: "break-word",
-              height: "500px",
-              padding: "10px",
-              backgroundColor: "#FFFFFF",
-              border: "1px solid",
-              borderColor: "#DEE2E6",
-              borderRadius: "20px",
-              marginTop: "50px",
-              marginBottom: "20px",
-              marginLeft: "150px",
-              marginRight: "150px",
-            }}
-          >
-            <h2
-              style={{ color: textGray, marginTop: "0px", marginBottom: "8px" }}
-            >{`${resourceType} IDs`}</h2>
-            <ResourceIDs jsonBody={pageBody}></ResourceIDs>
-          </div>
+          <Center>
+            <div
+              style={{
+                textAlign: "center",
+                overflowWrap: "break-word",
+                height: "500px",
+                padding: "10px",
+                backgroundColor: "#FFFFFF",
+                border: "1px solid",
+                borderColor: "#DEE2E6",
+                borderRadius: "20px",
+                marginTop: "10px",
+                marginBottom: "20px",
+                marginLeft: "150px",
+                marginRight: "150px",
+              }}
+            >
+              <ResourceIDs jsonBody={pageBody}></ResourceIDs>
+            </div>
+          </Center>
           {pageBody && pageBody.total
             ? pageBody.total > NUMBER_IDS_RENDERED_AT_A_TIME && (
                 <Center>

--- a/styles/codeColorScheme.tsx
+++ b/styles/codeColorScheme.tsx
@@ -1,6 +1,6 @@
 type stringArray = [string, string, string, string, string, string, string, string, string, string];
 
-export const replaceGray: stringArray = [
+export const AllDarkGray: stringArray = [
   "#ffffff",
   "#3b3f3f",
   "#3b3f3f",
@@ -13,7 +13,7 @@ export const replaceGray: stringArray = [
   "#3b3f3f",
 ];
 
-export const replaceDark: stringArray = [
+export const allWhite: stringArray = [
   "#FFFFFF",
   "#FFFFFF",
   "#FFFFFF",
@@ -26,20 +26,7 @@ export const replaceDark: stringArray = [
   "#FFFFFF",
 ];
 
-export const replaceTeal: stringArray = [
-  "#eb5262",
-  "#eb5262",
-  "#eb5262",
-  "#eb5262",
-  "#eb5262",
-  "#eb5262",
-  "#eb5262",
-  "#eb5262",
-  "#eb5262",
-  "#eb5262",
-];
-
-export const replaceRed: stringArray = [
+export const allGreen: stringArray = [
   "#00922A",
   "#00922A",
   "#00922A",
@@ -52,7 +39,7 @@ export const replaceRed: stringArray = [
   "#00922A",
 ];
 
-export const replaceBlue: stringArray = [
+export const allCobalt: stringArray = [
   "#1F44FF",
   "#1F44FF",
   "#1F44FF",
@@ -65,20 +52,20 @@ export const replaceBlue: stringArray = [
   "#1F44FF",
 ];
 
-export const replaceDelete: stringArray = [
-  "#A61E4D",
-  "#A61E4D",
-  "#A61E4D",
-  "#A61E4D",
-  "#A61E4D",
+export const shadesOfStrawberry: stringArray = [
+  "#eb5262",
+  "#eb5262",
+  "#eb5262",
+  "#eb5262",
+  "#eb5262",
   "#CE3D4C",
   "#EB5262",
-  "#CE3D4C",
-  "#A61E4D",
+  "#eb5262",
+  "#eb5262",
   "#A61E4D",
 ];
 
-export const replaceBackground: stringArray = [
+export const shadesOfGray: stringArray = [
   "#868E96",
   "#F1F3F5",
   "#E9ECEF",
@@ -91,7 +78,7 @@ export const replaceBackground: stringArray = [
   "#4a4f4f",
 ];
 
-export const replaceOutline: stringArray = [
+export const shadesOfCyan: stringArray = [
   "#E3FAFC",
   "#C5F6FA",
   "#99E9F2",
@@ -102,17 +89,4 @@ export const replaceOutline: stringArray = [
   "#1098AD",
   "#0C8599",
   "#0B7285",
-];
-
-export const replaceSecondRed: stringArray = [
-  "#EB5262",
-  "#EB5262",
-  "#EB5262",
-  "#EB5262;",
-  "#EB5262",
-  "#EB5262",
-  "#EB5262",
-  "#EB5262",
-  "#EB5262",
-  "#EB5262",
 ];


### PR DESCRIPTION
## Summary
Renders evaluate measure and care gaps buttons on specific resource pages to redirect to evaluate or care gaps page for a given measure. The corresponding fields are then pre-populated with data from the original resource page.  

## New behavior
Patient, Practitioner and Group resources now contain an evaluate measure button, and Patient, Practitioner, and Organization resources now contain a care gaps button. When clicked, these buttons allow the user to select a measure from a dropdown menu and reroute to that measure's evaluate or care gaps page. The patient, practitioner, group, and organization field is populated based on the original resource.  

## Code changes
- **components/ResourceMenu.tsx**, menu component added that displays clickable measure resources that navigate to the specified page 
- ** pages/[resourceType]/[id]/care-gaps.tsx**, added functionality to retrieve patient, organization, and practitioner information from the URL to prepopulate select fields. 
- ** pages/[resourceType]/[id]/evaluate-measure.tsx**, added functionality to retrieve patient, group, and practitioner information from the URL to prepopulate select fields.
- ** pages/[resourceType]/[id]/index.tsx**, renders care gap menu buttons on patient, practitioner, and organization resources and evaluate measure buttons on patient, practitioner, and group. 
- - **__tests__/pages/resource/id/index.test.tsx**, unit tests added
- - **__tests__/pages/resource/id/evaluate.test.tsx**, unit tests added
- - **__tests__/pages/resource/id/care-gaps.test.tsx**, unit tests added
## Testing Guidance
- See the README.md for first time setup instructions.
#### Testing in browser: 
To start the frontend: `npm run dev` then navigate to http://localhost:3001 in a browser
- Navigate to any patient resource ID page. Click on the evaluate measure button and select any measure from the drop down. You should be redirected to that measure’s evaluate measure page and the patient field should be pre-populated with the patient data. Click calculate and verify that the patient appears in the report. 
- Repeat this process with the care gaps button on the patient page. 
- Navigate to any participant resource ID page and repeat this process with the care gaps and evaluate measure buttons 
- Navigate to any group resource ID page and repeat this process with the evaluate measure button. Note that the care gaps button should not appear
- Navigate to any organization resource ID page and repeat this process with the care gaps button. Note that the evaluate measure button should not appear
#### Unit testing: 
- Run the unit tests: `npm run test`