### PR TITLE
Update $evaluate-measure to $evaluate

### DIFF
--- a/__tests__/pages/resource/id/evaluate.test.tsx
+++ b/__tests__/pages/resource/id/evaluate.test.tsx
@@ -106,7 +106,7 @@ describe("Test evaluate page render for measure", () => {
     //Request preview should include the dates from the Measure's effective period
     expect(
       screen.getByText(
-        "/Measure/measure-EXM104-8.2.000/$evaluate-measure?periodStart=2019-01-01&periodEnd=2019-12-31&reportType=subject",
+        "/Measure/measure-EXM104-8.2.000/$evaluate?periodStart=2019-01-01&periodEnd=2019-12-31&reportType=subject",
       ),
     ).toBeInTheDocument();
   });
@@ -158,7 +158,7 @@ describe("Test evaluate page render for measure", () => {
     //request preview should include the updated dates
     expect(
       screen.getByText(
-        "/Measure/measure-EXM104-8.2.000/$evaluate-measure?periodStart=2018-02-02&periodEnd=2020-11-13&reportType=subject",
+        "/Measure/measure-EXM104-8.2.000/$evaluate?periodStart=2018-02-02&periodEnd=2020-11-13&reportType=subject",
       ),
     ).toBeInTheDocument();
   });
@@ -295,7 +295,7 @@ describe("Select component, Radio button, and request preview render", () => {
     });
     expect(
       screen.getByText(
-        `/Measure/Measure-12/$evaluate-measure?periodStart=${DateTime.now().year}-01-01&periodEnd=${
+        `/Measure/Measure-12/$evaluate?periodStart=${DateTime.now().year}-01-01&periodEnd=${
           DateTime.now().year
         }-12-31&reportType=subject&subject=P&practitioner=P`,
       ),
@@ -332,7 +332,7 @@ describe("Select component, Radio button, and request preview render", () => {
 
     expect(
       screen.getByText(
-        `/Measure/Measure-12/$evaluate-measure?periodStart=${DateTime.now().year}-01-01&periodEnd=${
+        `/Measure/Measure-12/$evaluate?periodStart=${DateTime.now().year}-01-01&periodEnd=${
           DateTime.now().year
         }-12-31&reportType=population&subject=G`,
       ),

--- a/__tests__/pages/resource/id/index.test.tsx
+++ b/__tests__/pages/resource/id/index.test.tsx
@@ -22,7 +22,7 @@ describe("measure resource ID render", () => {
     global.fetch = getMockFetchImplementation("");
   });
 
-  it("should display button for evaluate measure and for care gaps", async () => {
+  it("should display button for evaluate and for care gaps", async () => {
     await act(async () => {
       render(
         <RouterContext.Provider
@@ -35,8 +35,8 @@ describe("measure resource ID render", () => {
       );
     });
 
-    //for Measure resources, "Evaluate Measure" and "Care Gaps" buttons will be in the document
-    expect(await screen.findByRole("link", { name: "Evaluate Measure" })).toBeInTheDocument();
+    //for Measure resources, "Evaluate" and "Care Gaps" buttons will be in the document
+    expect(await screen.findByRole("link", { name: "Evaluate" })).toBeInTheDocument();
     expect(await screen.findByRole("link", { name: "Care Gaps" })).toBeInTheDocument();
   });
 });
@@ -47,7 +47,7 @@ describe("resource ID page specific button renders", () => {
     global.fetch = getMockFetchImplementation("");
   });
 
-  it("should display button for evaluate measure and for care gaps on patient page", async () => {
+  it("should display button for evaluate and for care gaps on patient page", async () => {
     await act(async () => {
       render(
         <RouterContext.Provider
@@ -60,12 +60,12 @@ describe("resource ID page specific button renders", () => {
       );
     });
 
-    //for Patient resources, "Evaluate Measure" and "Calculate Care Gaps" buttons will be in the document
-    expect(await screen.findByRole("button", { name: "Evaluate Measure" })).toBeInTheDocument();
+    //for Patient resources, "Evaluate" and "Calculate Care Gaps" buttons will be in the document
+    expect(await screen.findByRole("button", { name: "Evaluate" })).toBeInTheDocument();
     expect(await screen.findByRole("button", { name: "Care Gaps" })).toBeInTheDocument();
   });
 
-  it("should display button for evaluate measure and for care gaps on practitioner page", async () => {
+  it("should display button for evaluate and for care gaps on practitioner page", async () => {
     await act(async () => {
       render(
         <RouterContext.Provider
@@ -78,12 +78,12 @@ describe("resource ID page specific button renders", () => {
       );
     });
 
-    //for Practitioner resources, "Evaluate Measure" and "Calculate Care Gaps" buttons will be in the document
-    expect(await screen.findByRole("button", { name: "Evaluate Measure" })).toBeInTheDocument();
+    //for Practitioner resources, "Evaluate" and "Calculate Care Gaps" buttons will be in the document
+    expect(await screen.findByRole("button", { name: "Evaluate" })).toBeInTheDocument();
     expect(await screen.findByRole("button", { name: "Care Gaps" })).toBeInTheDocument();
   });
 
-  it("should display button for evaluate measure on group page", async () => {
+  it("should display button for evaluate on group page", async () => {
     await act(async () => {
       render(
         <RouterContext.Provider
@@ -96,8 +96,8 @@ describe("resource ID page specific button renders", () => {
       );
     });
 
-    //for Group resources, "Evaluate Measure" and "Calculate Care Gaps" buttons will be in the document
-    expect(await screen.findByRole("button", { name: "Evaluate Measure" })).toBeInTheDocument();
+    //for Group resources, "Evaluate" and "Calculate Care Gaps" buttons will be in the document
+    expect(await screen.findByRole("button", { name: "Evaluate" })).toBeInTheDocument();
   });
 
   it("should display button for care gaps on organization page", async () => {
@@ -113,7 +113,7 @@ describe("resource ID page specific button renders", () => {
       );
     });
 
-    //for Organization resources, "Evaluate Measure" and "Calculate Care Gaps" buttons will be in the document
+    //for Organization resources, "Evaluate" and "Calculate Care Gaps" buttons will be in the document
     expect(await screen.findByRole("button", { name: "Care Gaps" })).toBeInTheDocument();
   });
 });
@@ -141,7 +141,7 @@ describe("resource ID render", () => {
     expect(await screen.findByTestId("back-button")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Update" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: "Evaluate Measure" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Evaluate" })).toBeNull();
     expect(screen.queryByRole("link", { name: "Calculate Care Gaps" })).toBeNull();
   });
 

--- a/__tests__/pages/resource/id/index.test.tsx
+++ b/__tests__/pages/resource/id/index.test.tsx
@@ -60,7 +60,7 @@ describe("resource ID page specific button renders", () => {
       );
     });
 
-    //for Patient resources, "Evaluate" and "Calculate Care Gaps" buttons will be in the document
+    //for Patient resources, "Evaluate" and "Care Gaps" buttons will be in the document
     expect(await screen.findByRole("button", { name: "Evaluate" })).toBeInTheDocument();
     expect(await screen.findByRole("button", { name: "Care Gaps" })).toBeInTheDocument();
   });
@@ -78,7 +78,7 @@ describe("resource ID page specific button renders", () => {
       );
     });
 
-    //for Practitioner resources, "Evaluate" and "Calculate Care Gaps" buttons will be in the document
+    //for Practitioner resources, "Evaluate" and "Care Gaps" buttons will be in the document
     expect(await screen.findByRole("button", { name: "Evaluate" })).toBeInTheDocument();
     expect(await screen.findByRole("button", { name: "Care Gaps" })).toBeInTheDocument();
   });
@@ -96,7 +96,7 @@ describe("resource ID page specific button renders", () => {
       );
     });
 
-    //for Group resources, "Evaluate" and "Calculate Care Gaps" buttons will be in the document
+    //for Group resources, "Evaluate" button will be in the document
     expect(await screen.findByRole("button", { name: "Evaluate" })).toBeInTheDocument();
   });
 
@@ -113,7 +113,7 @@ describe("resource ID page specific button renders", () => {
       );
     });
 
-    //for Organization resources, "Evaluate" and "Calculate Care Gaps" buttons will be in the document
+    //for Organization resources, "Care Gaps" button will be in the document
     expect(await screen.findByRole("button", { name: "Care Gaps" })).toBeInTheDocument();
   });
 });

--- a/pages/[resourceType]/[id]/evaluate.tsx
+++ b/pages/[resourceType]/[id]/evaluate.tsx
@@ -65,7 +65,7 @@ const EvaluateMeasurePage = () => {
    */
   const createRequestPreview = () => {
     //dates are formatted to be in the form "YYYY-MM-DD", with no timezone info
-    let requestPreview = `/Measure/${id}/$evaluate-measure?periodStart=${DateTime.fromISO(
+    let requestPreview = `/Measure/${id}/$evaluate?periodStart=${DateTime.fromISO(
       periodStart.toISOString(),
     ).toISODate()}&periodEnd=${DateTime.fromISO(periodEnd.toISOString()).toISODate()}`;
     if (radioValue) {

--- a/pages/[resourceType]/[id]/index.tsx
+++ b/pages/[resourceType]/[id]/index.tsx
@@ -18,7 +18,7 @@ import { fhirJson } from "@fhir-typescript/r4-core";
 import ResourceMenu from "../../../components/ResourceMenu";
 /**
  * Component which displays the JSON body of an individual resource and a back button.
- * If the resource is a Measure, an evaluate measure button is also displayed.
+ * If the resource is a Measure, an evaluate button is also displayed.
  * @returns JSON content of the individual resource in a Prism component, and a back button
  */
 function ResourceIDPage() {
@@ -120,7 +120,7 @@ function ResourceIDPage() {
                 marginLeft: "8px",
               }}
             >
-              <div>Evaluate Measure</div>
+              <div>Evaluate</div>
             </Button>
           </Link>{" "}
           <Link href={`/Measure/${id}/care-gaps`} key={`care-gaps-${id}`} passHref>
@@ -141,7 +141,7 @@ function ResourceIDPage() {
           </Link>
         </div>
       )}
-      {/** limits which pages display evaluate measure and care gap buttons */}
+      {/** limits which pages display evaluate and care gap buttons */}
       {/** both buttons display a drop down menu with measure resource options */}
       {(resourceType === "Patient" || resourceType === "Practitioner") && (
         <div>
@@ -150,7 +150,7 @@ function ResourceIDPage() {
             id={id}
             bundleEntry={bundleEntry}
             url="evaluate"
-            label="Evaluate Measure"
+            label="Evaluate"
           />
           <ResourceMenu
             resourceType={resourceType}
@@ -179,7 +179,7 @@ function ResourceIDPage() {
             id={id}
             bundleEntry={bundleEntry}
             url="evaluate"
-            label="Evaluate Measure"
+            label="Evaluate"
           />
         </div>
       )}

--- a/pages/[resourceType]/[id]/index.tsx
+++ b/pages/[resourceType]/[id]/index.tsx
@@ -107,7 +107,7 @@ function ResourceIDPage() {
 
       {resourceType === "Measure" && (
         <div>
-          <Link href={`/Measure/${id}/evaluate`} key={`evaluate-measure-${id}`} passHref>
+          <Link href={`/Measure/${id}/evaluate`} key={`evaluate-${id}`} passHref>
             <Button
               component="a"
               color="cyan"


### PR DESCRIPTION
## Summary
This PR updates instances of `$evaluate-measure` to `evaluate` to align with the latest [DEQM definiton of the operation](https://build.fhir.org/ig/HL7/davinci-deqm/OperationDefinition-evaluate.html) as well as our [deqm-test-server](https://github.com/projecttacoma/deqm-test-server).

## Testing
- `npm run check`
- In deqm-test-server: `npm run start` 
- In deqm-test-server-frontend: `npm run dev`
- Make sure I didn't miss any instances of `$evaluate-measure`